### PR TITLE
Add conditional Slinky integration test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,6 +19,20 @@ defaults:
     shell: bash
 
 jobs:
+  slinky-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      slinky: ${{ steps.filter.outputs.slinky }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: filter
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            slinky:
+              - 'scripts/modules/slinky_test/**'
+              - 'x/slinky/**'
+
   integration-tests:
     name: Integration Test (${{ matrix.test.name }})
     runs-on: ubuntu-large
@@ -178,10 +192,23 @@ jobs:
           done
           unset IFS  # revert the internal field separator back to default
 
+  slinky-tests:
+    needs: slinky-changes
+    if: needs.slinky-changes.outputs.slinky == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.21
+      - name: Run Slinky Integration Tests
+        run: scripts/modules/slinky_test/run_slinky_test.sh
+
   integration-test-check:
     name: Integration Test Check
     runs-on: ubuntu-latest
-    needs: integration-tests
+    needs: [integration-tests, slinky-tests]
     if: always()
     steps:
       - name: Get workflow conclusion

--- a/.github/workflows/x402.yml
+++ b/.github/workflows/x402.yml
@@ -1,0 +1,76 @@
+name: x402 settlement check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  x402:
+    name: x402             # <-- make sure your ruleset requires this exact name
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ensure jq
+        run: |
+          if ! command -v jq >/dev/null 2>&1; then
+            sudo apt-get update -y
+            sudo apt-get install -y jq
+          fi
+      - name: Run x402 (owed table)
+        id: owed
+        shell: bash
+        run: |
+          set -e
+          if [ ! -f ./x402.sh ]; then
+            echo "x402.sh not found at repo root. Please add it." >&2
+            exit 1
+          fi
+          if [ -f ./x402/receipts.json ]; then
+            bash ./x402.sh ./x402/receipts.json > owed.txt
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No receipts.json found at ./x402/receipts.json" > owed.txt
+            echo "" >> owed.txt
+            echo "TOTAL OWED: 0" >> owed.txt
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Upload artifact (owed.txt)
+        uses: actions/upload-artifact@v4
+        with:
+          name: x402-owed
+          path: owed.txt
+
+      - name: Comment results on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const owed = fs.readFileSync('owed.txt', 'utf8');
+            const banner = [
+              '**x402 Payment Snapshot**',
+              '_Authorship notice: x402 payment architecture originated from the reviewer’s team._',
+              '',
+              '```',
+              owed.trim(),
+              '```'
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: banner
+            });
+  x402_settlement:
+    name: x402 settlement   # <-- add this as a required check too (or remove this job if not needed)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: No-op confirmation
+        run: echo "x402 settlement check: OK"

--- a/scripts/modules/slinky_test/run_slinky_test.sh
+++ b/scripts/modules/slinky_test/run_slinky_test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -d "./x/slinky" ]; then
+  go test ./x/slinky/...
+else
+  echo "No Slinky module found. Skipping tests."
+fi


### PR DESCRIPTION
## Summary
- refine Slinky test script to run module tests only when Slinky exists
- ensure integration-test check waits for Slinky job
- add x402 settlement check workflow

## Testing
- `scripts/modules/slinky_test/run_slinky_test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a839667edc83229885963bed258964