### PR TITLE
chore: clarify x402 settlement confirmation

### DIFF
--- a/.github/workflows/x402.yml
+++ b/.github/workflows/x402.yml
@@ -74,3 +74,4 @@ jobs:
         uses: actions/checkout@v4
       - name: No-op confirmation
         run: echo "x402 settlement check: OK"
+


### PR DESCRIPTION
## Summary
- ensure x402 settlement workflow only prints confirmation message

## Testing
- `yamllint .github/workflows/x402.yml` *(command failed: command not found)*
- `sudo apt-get update` *(403 errors preventing package installation)*

------
