### PR TITLE
Add prototype SeiSecurityProxy contract and skeleton test

### DIFF
--- a/contracts/src/SeiSecurityProxy.sol
+++ b/contracts/src/SeiSecurityProxy.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title SeiSecurityProxy
+/// @notice Minimal stateless proxy exposing hooks for security modules.
+/// @dev Implements role gating, proof decoding, memo interpretation and
+/// recovery guard callbacks as described by the Advanced Security Proxy
+/// Architecture.
+contract SeiSecurityProxy {
+    address public roleGate;
+    address public proofDecoder;
+    address public memoInterpreter;
+    address public recoveryGuard;
+
+    event RoleGateUpdated(address indexed newGate);
+    event ProofDecoderUpdated(address indexed newDecoder);
+    event MemoInterpreterUpdated(address indexed newInterpreter);
+    event RecoveryGuardUpdated(address indexed newGuard);
+
+    modifier onlyRole(bytes32 role, address account) {
+        require(IRoleGate(roleGate).checkRole(role, account), "role denied");
+        _;
+    }
+
+    function setRoleGate(address gate) external {
+        roleGate = gate;
+        emit RoleGateUpdated(gate);
+    }
+
+    function setProofDecoder(address decoder) external {
+        proofDecoder = decoder;
+        emit ProofDecoderUpdated(decoder);
+    }
+
+    function setMemoInterpreter(address interpreter) external {
+        memoInterpreter = interpreter;
+        emit MemoInterpreterUpdated(interpreter);
+    }
+
+    function setRecoveryGuard(address guard) external {
+        recoveryGuard = guard;
+        emit RecoveryGuardUpdated(guard);
+    }
+
+    function execute(
+        bytes32 role,
+        bytes calldata proof,
+        bytes calldata memo,
+        address target,
+        bytes calldata data
+    ) external onlyRole(role, msg.sender) returns (bytes memory) {
+        require(IProofDecoder(proofDecoder).decode(proof, msg.sender), "invalid proof");
+        IMemoInterpreter(memoInterpreter).interpret(memo, msg.sender, target);
+        IRecoveryGuard(recoveryGuard).beforeCall(msg.sender, target, data);
+        (bool ok, bytes memory res) = target.call(data);
+        if (!ok) {
+            IRecoveryGuard(recoveryGuard).handleFailure(msg.sender, target, data);
+            revert("call failed");
+        }
+        IRecoveryGuard(recoveryGuard).afterCall(msg.sender, target, data, res);
+        return res;
+    }
+}
+
+interface IRoleGate {
+    function checkRole(bytes32 role, address account) external view returns (bool);
+}
+
+interface IProofDecoder {
+    function decode(bytes calldata proof, address account) external view returns (bool);
+}
+
+interface IMemoInterpreter {
+    function interpret(bytes calldata memo, address account, address target) external;
+}
+
+interface IRecoveryGuard {
+    function beforeCall(address account, address target, bytes calldata data) external;
+    function handleFailure(address account, address target, bytes calldata data) external;
+    function afterCall(address account, address target, bytes calldata data, bytes calldata result) external;
+}

--- a/contracts/src/SeiSecurityProxyMocks.sol
+++ b/contracts/src/SeiSecurityProxyMocks.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./SeiSecurityProxy.sol";
+
+/// @notice Simple mock implementations of proxy modules used in tests.
+contract MockRoleGate is IRoleGate {
+    bytes32 public constant DEFAULT_ROLE = keccak256("DEFAULT_ROLE");
+    function checkRole(bytes32 role, address) external pure override returns (bool) {
+        return role == DEFAULT_ROLE;
+    }
+}
+
+contract MockProofDecoder is IProofDecoder {
+    function decode(bytes calldata, address) external pure override returns (bool) {
+        return true;
+    }
+}
+
+contract MockMemoInterpreter is IMemoInterpreter {
+    event Memo(address sender, bytes memo, address target);
+    function interpret(bytes calldata memo, address sender, address target) external override {
+        emit Memo(sender, memo, target);
+    }
+}
+
+contract MockRecoveryGuard is IRecoveryGuard {
+    event Before(address sender, address target);
+    event After(address sender, address target);
+    function beforeCall(address account, address target, bytes calldata) external override {
+        emit Before(account, target);
+    }
+    function handleFailure(address, address, bytes calldata) external pure override {}
+    function afterCall(address account, address target, bytes calldata, bytes calldata) external override {
+        emit After(account, target);
+    }
+}

--- a/contracts/test/SeiSecurityProxyTest.js
+++ b/contracts/test/SeiSecurityProxyTest.js
@@ -1,0 +1,41 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("SeiSecurityProxy", function () {
+  it("executes call through security modules", async function () {
+    const RoleGate = await ethers.getContractFactory("MockRoleGate");
+    const ProofDecoder = await ethers.getContractFactory("MockProofDecoder");
+    const MemoInterpreter = await ethers.getContractFactory("MockMemoInterpreter");
+    const RecoveryGuard = await ethers.getContractFactory("MockRecoveryGuard");
+    const Proxy = await ethers.getContractFactory("SeiSecurityProxy");
+    const Box = await ethers.getContractFactory("Box");
+
+    const [roleGate, proofDecoder, memoInterpreter, recoveryGuard, proxy, box] = await Promise.all([
+      RoleGate.deploy(),
+      ProofDecoder.deploy(),
+      MemoInterpreter.deploy(),
+      RecoveryGuard.deploy(),
+      Proxy.deploy(),
+      Box.deploy()
+    ]);
+
+    await Promise.all([
+      roleGate.waitForDeployment(),
+      proofDecoder.waitForDeployment(),
+      memoInterpreter.waitForDeployment(),
+      recoveryGuard.waitForDeployment(),
+      proxy.waitForDeployment(),
+      box.waitForDeployment()
+    ]);
+
+    await proxy.setRoleGate(roleGate.target);
+    await proxy.setProofDecoder(proofDecoder.target);
+    await proxy.setMemoInterpreter(memoInterpreter.target);
+    await proxy.setRecoveryGuard(recoveryGuard.target);
+
+    const role = await roleGate.DEFAULT_ROLE();
+    const calldata = box.interface.encodeFunctionData("store", [123]);
+    await expect(proxy.execute(role, "0x", "0x", box.target, calldata)).to.not.be.reverted;
+    expect(await box.retrieve()).to.equal(123n);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce SeiSecurityProxy contract with hooks for role gating, proof decoding, memo interpretation and recovery guard
- add mock module implementations and a basic Hardhat test wiring the proxy

## Testing
- `npx hardhat test test/SeiSecurityProxyTest.js` *(fails: 403 Forbidden - GET https://registry.npmjs.org/hardhat)*

------
