### PR TITLE
Add tokenfactory mint/burn coverage to balance verifier

### DIFF
--- a/tests/tokenfactory_balance_test.go
+++ b/tests/tokenfactory_balance_test.go
@@ -1,0 +1,30 @@
+package tests
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/signing"
+	"github.com/sei-protocol/sei-chain/testutil/processblock"
+	"github.com/sei-protocol/sei-chain/testutil/processblock/verify"
+	tokenfactorytypes "github.com/sei-protocol/sei-chain/x/tokenfactory/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenFactoryMintBurnBalance(t *testing.T) {
+	app := processblock.NewTestApp()
+	p := processblock.CommonPreset(app)
+
+	denom, err := tokenfactorytypes.GetTokenDenom(p.Admin.String(), "tf")
+	require.NoError(t, err)
+
+	txs := []signing.Tx{
+		p.AdminSign(app, tokenfactorytypes.NewMsgCreateDenom(p.Admin.String(), "tf")),
+		p.AdminSign(app, tokenfactorytypes.NewMsgMint(p.Admin.String(), sdk.NewCoin(denom, sdk.NewInt(1000)))),
+		p.AdminSign(app, tokenfactorytypes.NewMsgBurn(p.Admin.String(), sdk.NewCoin(denom, sdk.NewInt(400)))),
+	}
+
+	blockRunner := func() []uint32 { return app.RunBlock(txs) }
+	blockRunner = verify.Balance(t, app, blockRunner, txs)
+	require.Equal(t, []uint32{0, 0, 0}, blockRunner())
+}

--- a/testutil/processblock/verify/bank.go
+++ b/testutil/processblock/verify/bank.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/signing"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/sei-protocol/sei-chain/testutil/processblock"
+	tokenfactorytypes "github.com/sei-protocol/sei-chain/x/tokenfactory/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,6 +32,10 @@ func Balance(t *testing.T, app *processblock.App, f BlockRunnable, txs []signing
 					for _, output := range m.Outputs {
 						updateMultipleExpectedBalanceChange(expectedChanges, output.Address, output.Coins, true)
 					}
+				case *tokenfactorytypes.MsgMint:
+					updateExpectedBalanceChange(expectedChanges, m.Sender, m.Amount, true)
+				case *tokenfactorytypes.MsgBurn:
+					updateExpectedBalanceChange(expectedChanges, m.Sender, m.Amount, false)
 				default:
 					// TODO: add coverage for other balance-affecting messages to enable testing for those message types
 					continue


### PR DESCRIPTION
## Summary
- handle MsgMint and MsgBurn in Balance verifier
- test balance updates for tokenfactory mint and burn

## Testing
- `go test ./testutil/processblock/verify` *(fails: github.com/sei-protocol/sei-cosmos@v0.3.66: Forbidden)*
- `go test ./tests -run TestTokenFactoryMintBurnBalance -count=1` *(fails: github.com/sei-protocol/sei-cosmos@v0.3.66: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68afd3a7b63c8322b3c13f22bd60c7df