### PR TITLE
feat(migration): make IAVL cache size configurable

### DIFF
--- a/cmd/seid/cmd/root.go
+++ b/cmd/seid/cmd/root.go
@@ -224,6 +224,7 @@ func addModuleInitFlags(startCmd *cobra.Command) {
 	crisis.AddModuleInitFlags(startCmd)
 	startCmd.Flags().Bool("migrate-iavl", false, "Run migration of IAVL data store to SeiDB State Store")
 	startCmd.Flags().Int64("migrate-height", 0, "Height at which to start the migration")
+	startCmd.Flags().Int("migrate-cache-size", ss.DefaultCacheSize, "IAVL cache size to use during migration")
 }
 
 // newApp creates a new Cosmos SDK app
@@ -313,7 +314,8 @@ func newApp(
 			homeDir := cast.ToString(appOpts.Get(flags.FlagHome))
 			stateStore := app.GetStateStore()
 			migrationHeight := cast.ToInt64(appOpts.Get("migrate-height"))
-			migrator := ss.NewMigrator(db, stateStore)
+			cacheSize := cast.ToInt(appOpts.Get("migrate-cache-size"))
+			migrator := ss.NewMigrator(db, stateStore, cacheSize)
 			if err := migrator.Migrate(migrationHeight, homeDir); err != nil {
 				panic(err)
 			}

--- a/docs/migration/seidb_archive_migration.md
+++ b/docs/migration/seidb_archive_migration.md
@@ -12,7 +12,7 @@ The overall process will work as follows:
 1. Update config to enable SeiDB (state committment + state store)
 2. Stop the node and Run SC Migration
 3. Note down MIGRATION_HEIGHT
-4. Re start seid with `--migrate-iavl` enabled (migrating state store in background)
+4. Re start seid with `--migrate-iavl` enabled (migrating state store in background, optional `--migrate-cache-size` to adjust IAVL cache)
 5. Verify migration at various sampled heights once state store is complete
 6. Restart seid normally and verify node runs properly
 7. Clear out iavl and restart seid normally, now only using SeiDB fully
@@ -131,7 +131,7 @@ MIGRATION_HEIGHT=<>
 If you are using systemd, make sure to update your service configuration to use this command.
 Always be sure to run with these flags until migration is complete.
 ```bash
-seid start --migrate-iavl --migrate-height $MIGRATION_HEIGHT --chain-id pacific-1
+seid start --migrate-iavl --migrate-height $MIGRATION_HEIGHT --migrate-cache-size 10000 --chain-id pacific-1
 ```
 
 Seid will run normally and the migration will run in the background. Data from iavl
@@ -156,7 +156,7 @@ all keys in iavl at a specific height and verify they exist in State Store.
 
 You should run the following command for a selection of different heights
 ```bash
-seid tools verify-migration --version $VERIFICATION_HEIGHT
+seid tools verify-migration --version $VERIFICATION_HEIGHT --cache-size 10000
 ```
 
 This will output `Verification Succeeded` if the verification was successful.

--- a/tools/migration/cmd/cmd.go
+++ b/tools/migration/cmd/cmd.go
@@ -57,6 +57,7 @@ func VerifyMigrationCmd() *cobra.Command {
 
 	cmd.PersistentFlags().Int64("version", -1, "Version to run migration verification on")
 	cmd.PersistentFlags().String("home-dir", "/root/.sei", "Sei home directory")
+	cmd.PersistentFlags().Int("cache-size", ss.DefaultCacheSize, "IAVL cache size to use during verification")
 
 	return cmd
 }
@@ -64,6 +65,7 @@ func VerifyMigrationCmd() *cobra.Command {
 func verify(cmd *cobra.Command, _ []string) {
 	homeDir, _ := cmd.Flags().GetString("home-dir")
 	version, _ := cmd.Flags().GetInt64("version")
+	cacheSize, _ := cmd.Flags().GetInt("cache-size")
 
 	fmt.Printf("version %d\n", version)
 
@@ -77,7 +79,7 @@ func verify(cmd *cobra.Command, _ []string) {
 		panic(err)
 	}
 
-	err = verifySS(version, homeDir, db)
+	err = verifySS(version, cacheSize, homeDir, db)
 	if err != nil {
 		fmt.Printf("Verification Failed with err: %s\n", err.Error())
 		return
@@ -86,7 +88,7 @@ func verify(cmd *cobra.Command, _ []string) {
 	fmt.Println("Verification Succeeded")
 }
 
-func verifySS(version int64, homeDir string, db dbm.DB) error {
+func verifySS(version int64, cacheSize int, homeDir string, db dbm.DB) error {
 	ssConfig := config.DefaultStateStoreConfig()
 	ssConfig.Enable = true
 
@@ -95,7 +97,7 @@ func verifySS(version int64, homeDir string, db dbm.DB) error {
 		return err
 	}
 
-	migrator := ss.NewMigrator(db, stateStore)
+	migrator := ss.NewMigrator(db, stateStore, cacheSize)
 	return migrator.Verify(version)
 }
 

--- a/tools/migration/ss/migrator_test.go
+++ b/tools/migration/ss/migrator_test.go
@@ -1,0 +1,12 @@
+package ss
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMigratorCacheSize(t *testing.T) {
+	m := NewMigrator(nil, nil, 12345)
+	require.Equal(t, 12345, m.cacheSize)
+}


### PR DESCRIPTION
## Summary
- allow specifying IAVL cache size for state store migration and verification
- document new `migrate-cache-size` and `cache-size` flags
- test migrator accepts custom cache size

## Testing
- `go test ./tools/migration/ss -run TestNewMigratorCacheSize -count=1` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68afd5aeb5c48322910f655f1384630f