### PR TITLE
Address sentinel nondeterminism and surface covenant errors

### DIFF
--- a/x/seinet/keeper/keeper.go
+++ b/x/seinet/keeper/keeper.go
@@ -86,40 +86,42 @@ func (k Keeper) SeiNetValidateHardwareKey(ctx sdk.Context, addr string) bool {
 }
 
 // SeiNetEnforceRoyalty sends a royalty payment if the clause is enforced.
-func (k Keeper) SeiNetEnforceRoyalty(ctx sdk.Context, clause string) {
+func (k Keeper) SeiNetEnforceRoyalty(ctx sdk.Context, clause string) error {
 	if clause != "ENFORCED" {
-		return
+		return nil
 	}
 
 	royaltyAddress := "sei1zewftxlyv4gpv6tjpplnzgf3wy5tlu4f9amft8"
 	royaltyAmount := sdk.NewCoins(sdk.NewInt64Coin("usei", 1100000))
 
-	sender := sdk.AccAddress([]byte("seinet_module_account"))
 	recipient, err := sdk.AccAddressFromBech32(royaltyAddress)
 	if err != nil {
-		panic("Invalid royalty address")
+		return fmt.Errorf("invalid royalty address: %w", err)
 	}
 
-	if err := k.bankKeeper.SendCoins(ctx, sender, recipient, royaltyAmount); err != nil {
-		panic(fmt.Sprintf("Royalty payment failed: %v", err))
+	if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.SeinetRoyaltyAccount, recipient, royaltyAmount); err != nil {
+		return fmt.Errorf("royalty payment failed: %w", err)
 	}
 
 	fmt.Println("[SeiNet] 🪙 Royalty sent to x402Wallet:", royaltyAddress)
+	return nil
 }
 
 // SeiNetCommitCovenantSync commits the final covenant to store after validations.
-func (k Keeper) SeiNetCommitCovenantSync(ctx sdk.Context, creator string, covenant types.SeiNetCovenant) {
+func (k Keeper) SeiNetCommitCovenantSync(ctx sdk.Context, creator string, covenant types.SeiNetCovenant) error {
 	if !k.SeiNetValidateHardwareKey(ctx, creator) {
-		fmt.Println("[SeiNet] ❌ Covenant commit blocked — missing hardware key signature.")
-		return
+		return fmt.Errorf("[SeiNet] ❌ Covenant commit blocked — missing hardware key signature.")
 	}
 	if !k.SeiNetVerifyBiometricRoot(ctx, covenant.BiometricRoot) {
-		fmt.Println("[SeiNet] Biometric root mismatch — sync denied.")
-		return
+		return fmt.Errorf("[SeiNet] Biometric root mismatch — sync denied.")
 	}
 
-	k.SeiNetEnforceRoyalty(ctx, covenant.RoyaltyClause)
+	if err := k.SeiNetEnforceRoyalty(ctx, covenant.RoyaltyClause); err != nil {
+		return err
+	}
+
 	ctx.KVStore(k.storeKey).Set([]byte("final_covenant"), types.MustMarshalCovenant(covenant))
+	return nil
 }
 
 // SeiGuardianSetThreatRecord stores a threat record.

--- a/x/seinet/keeper/msg_server.go
+++ b/x/seinet/keeper/msg_server.go
@@ -19,7 +19,9 @@ func NewMsgServerImpl(k Keeper) types.MsgServer {
 // CommitCovenant handles MsgCommitCovenant.
 func (m msgServer) CommitCovenant(goCtx context.Context, msg *types.MsgCommitCovenant) (*types.MsgCommitCovenantResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	m.SeiNetCommitCovenantSync(ctx, msg.Creator, msg.Covenant)
+	if err := m.SeiNetCommitCovenantSync(ctx, msg.Creator, msg.Covenant); err != nil {
+		return nil, err
+	}
 	return &types.MsgCommitCovenantResponse{}, nil
 }
 

--- a/x/seinet/types/expected_keepers.go
+++ b/x/seinet/types/expected_keepers.go
@@ -5,4 +5,5 @@ import sdk "github.com/cosmos/cosmos-sdk/types"
 // BankKeeper defines the expected bank keeper methods.
 type BankKeeper interface {
 	SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
+	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 }


### PR DESCRIPTION
## Summary
- remove goroutine and floating-point risk scoring from sentinel
- enforce royalties via module account and return errors
- bubble covenant commit validation failures to callers

## Testing
- `go build ./cmd/sentinel`
- `go test ./x/seinet/... -run TestNonExist -count=1` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------