### PR TITLE
Fail fast if local seid node is unavailable

### DIFF
--- a/integration_test/launch.sh
+++ b/integration_test/launch.sh
@@ -17,14 +17,22 @@ SEID_PID=$!
 
 # Wait until RPC is alive
 echo "[INFO] Waiting for seid RPC to respond..."
+ready=false
 for i in {1..30}; do
   if curl -s http://localhost:26657/status > /dev/null; then
     echo "[INFO] seid node is up!"
+    ready=true
     break
   fi
   echo "[INFO] Attempt $i — seid not ready yet..."
   sleep 2
 done
+
+if [ "$ready" = false ]; then
+  echo "[ERROR] seid failed to start" >&2
+  kill "$SEID_PID" >/dev/null 2>&1 || true
+  exit 1
+fi
 
 # Write the launch.complete marker
 echo "node started at $(date)" > build/generated/launch.complete


### PR DESCRIPTION
## Summary
- exit `integration_test/launch.sh` when the seid RPC fails to come up

## Testing
- `bash -n integration_test/launch.sh`
- `go test ./...` *(fails: `github.com/sei-protocol/go-ethereum@v1.15.7-sei-3: Get "https://proxy.golang.org/...zip": Forbidden`)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e30db558832290c47f8ee9076efb