### PR TITLE
fix: clean up wasm module script list

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -45,7 +45,6 @@ jobs:
               - python3 integration_test/scripts/runner.py integration_test/wasm_module/timelocked_token_withdraw_test.yaml
               - docker exec sei-node-0 integration_test/contracts/deploy_timelocked_token_contract.sh
               - python3 integration_test/scripts/runner.py integration_test/wasm_module/timelocked_token_emergency_withdraw_test.yaml
-
           - name: Mint & Staking & Bank Module
             scripts:
               - python3 integration_test/scripts/runner.py integration_test/staking_module/staking_test.yaml


### PR DESCRIPTION
## Summary
- remove stray newline after timelocked token emergency withdraw test step in integration workflow

## Testing
- `go test ./...` *(fails: github.com/sei-protocol/go-ethereum@v1.15.7-sei-3: Get "https://proxy.golang.org/github.com/sei-protocol/go-ethereum/@v/v1.15.7-sei-3.zip": Forbidden)*

------