### PR TITLE
refactor: simplify golangci-lint workflow

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -2,58 +2,27 @@ name: golangci-lint
 
 on:
   push:
+    branches: [main, master, seiv2]
     tags:
       - v*
-    branches:
-      - master
-      - main
-      - seiv2
   pull_request:
 
 permissions:
   contents: read
-  # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  # pull-requests: read
 
 jobs:
   golangci:
-    name: lint
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-
-      - name: Setup Go
-        uses: actions/setup-go@v4
+      - uses: actions/setup-go@v3
         with:
-          go-version: "1.24"
+          go-version: 1.21
 
-      - name: Check for go.sum
-        id: check_go_sum
-        run: |
-          if [ ! -f go.sum ]; then
-            echo "🟡 No go.sum found — skipping golangci-lint."
-            echo "skip_lint=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-      - name: Install golangci-lint
-        if: steps.check_go_sum.outputs.skip_lint != 'true'
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-            | sh -s -- -b $(go env GOPATH)/bin v1.55.2
+      - uses: actions/checkout@v3
 
       - name: Run golangci-lint
-        if: steps.check_go_sum.outputs.skip_lint != 'true'
-        id: golangci
-        run: |
-          golangci-lint run ./... --out-format tab > golangci-lint-report.txt
-        continue-on-error: true
-
-      - name: Upload golangci-lint report (only on failure)
-        if: steps.golangci.outcome == 'failure'
-        uses: actions/upload-artifact@v3
+        uses: golangci/golangci-lint-action@v3
         with:
-          name: golangci-lint-report
-          path: golangci-lint-report.txt
+          version: v1.60.1
+          args: --timeout 10m0s
+


### PR DESCRIPTION
## Summary
- replace custom lint setup with official golangci-lint action
- configure Go 1.21 and 10m timeout

## Testing
- `yamllint .github/workflows/golangci.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: Could not connect to proxy)*

------