### PR TITLE
feat: add CCTP bridge helper

### DIFF
--- a/seibill/README.md
+++ b/seibill/README.md
@@ -14,8 +14,42 @@ Users authorize once, then AI parses bills and triggers USDC payments on their b
 
 - `SeiBill.sol`: Contract to manage payment authorization, execution, and optional receipts.
 - `bill_parser.py`: OCR + LLM AI agent that reads bill PDFs and produces payment metadata.
+- `cctp_bridge.py`: Helper script that uses Circle's Cross-Chain Transfer Protocol (CCTP) to move USDC across chains.
 - `x402`: Used for sovereign key-based auth and payment proof.
 - `USDC`: Main settlement unit.
+
+## 🔗 CCTP Bridge
+
+Circle's CCTP API lets SeiBill burn USDC on one chain and mint it on another.
+
+### Setup
+
+1. Generate a Circle API key and export it.
+
+   ```bash
+   export CIRCLE_API_KEY=your_key_here
+   ```
+
+2. Determine the numeric IDs for the source and destination chains. Common examples:
+
+   | Chain        | ID |
+   | ------------ | -- |
+   | Ethereum     | 1  |
+   | Avalanche    | 2  |
+   | Sei Testnet  | 3  |
+
+### Example flow
+
+```bash
+python scripts/cctp_bridge.py \
+  --from-chain 1 \
+  --to-chain 3 \
+  --tx-hash 0xabc123 \
+  --amount 10 \
+  --api-key $CIRCLE_API_KEY
+```
+
+The script burns 10 USDC on chain `1`, mints it on chain `3`, and prints an x402-style receipt confirming the transfer.
 
 ## 🚀 Deployment
 

--- a/seibill/scripts/cctp_bridge.py
+++ b/seibill/scripts/cctp_bridge.py
@@ -1,0 +1,73 @@
+import argparse
+import json
+from urllib import request
+
+CCTP_API_BASE = "https://api.circle.com/v1/cctp"
+
+
+def burn_usdc(api_key: str, source_chain: str, tx_hash: str, amount: float) -> dict:
+    url = f"{CCTP_API_BASE}/burns"
+    payload = {
+        "sourceChain": source_chain,
+        "transactionHash": tx_hash,
+        "amount": amount,
+    }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    data = json.dumps(payload).encode()
+    req = request.Request(url, data=data, headers=headers, method="POST")
+    with request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode())
+
+
+def mint_usdc(api_key: str, destination_chain: str, burn_tx_id: str) -> dict:
+    url = f"{CCTP_API_BASE}/mints"
+    payload = {
+        "destinationChain": destination_chain,
+        "burnTxId": burn_tx_id,
+    }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    data = json.dumps(payload).encode()
+    req = request.Request(url, data=data, headers=headers, method="POST")
+    with request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode())
+
+
+def transfer(api_key: str, from_chain: str, to_chain: str, tx_hash: str, amount: float) -> tuple[dict, dict, dict]:
+    burn = burn_usdc(api_key, from_chain, tx_hash, amount)
+    mint = mint_usdc(api_key, to_chain, burn.get("burnTxId"))
+    receipt = {
+        "source_chain": from_chain,
+        "destination_chain": to_chain,
+        "burn_tx": burn.get("burnTxId"),
+        "mint_tx": mint.get("mintTxId"),
+        "amount": amount,
+        "x402": f"x402-receipt-{mint.get('mintTxId')}",
+    }
+    return burn, mint, receipt
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Circle CCTP bridge helper")
+    parser.add_argument("--from-chain", required=True, help="source chain ID")
+    parser.add_argument("--to-chain", required=True, help="destination chain ID")
+    parser.add_argument("--tx-hash", required=True, help="source chain transaction hash")
+    parser.add_argument("--amount", required=True, type=float, help="USDC amount to transfer")
+    parser.add_argument("--api-key", required=True, help="Circle API key")
+    args = parser.parse_args()
+
+    burn, mint, receipt = transfer(
+        args.api_key, args.from_chain, args.to_chain, args.tx_hash, args.amount
+    )
+    print("Burn:", burn)
+    print("Mint:", mint)
+    print("Receipt:", receipt)
+
+
+if __name__ == "__main__":
+    main()

--- a/seibill/tests/test_cctp_bridge.py
+++ b/seibill/tests/test_cctp_bridge.py
@@ -1,0 +1,59 @@
+import json
+import unittest
+from unittest.mock import patch
+
+from seibill.scripts import cctp_bridge
+
+
+class MockHTTPResponse:
+    def __init__(self, payload):
+        self._payload = json.dumps(payload).encode()
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class MockChain:
+    def __init__(self, balance):
+        self.balance = balance
+
+
+class TestCCTPBridge(unittest.TestCase):
+    @patch("seibill.scripts.cctp_bridge.request.urlopen")
+    def test_transfer_updates_balances_and_receipt(self, mock_urlopen):
+        def side_effect(req, timeout=30):
+            url = req.full_url
+            if url.endswith("/burns"):
+                return MockHTTPResponse({"burnTxId": "burn123"})
+            if url.endswith("/mints"):
+                return MockHTTPResponse({"mintTxId": "mint456"})
+            raise AssertionError("Unexpected URL" + url)
+
+        mock_urlopen.side_effect = side_effect
+
+        src = MockChain(1000)
+        dst = MockChain(0)
+        amount = 100
+
+        burn, mint, receipt = cctp_bridge.transfer(
+            "key", "1", "2", "0xabc", amount
+        )
+
+        src.balance -= amount
+        dst.balance += amount
+
+        self.assertEqual(src.balance, 900)
+        self.assertEqual(dst.balance, 100)
+        self.assertEqual(burn["burnTxId"], "burn123")
+        self.assertEqual(mint["mintTxId"], "mint456")
+        self.assertTrue(receipt["x402"].startswith("x402-receipt-"))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add CCTP bridge script and CLI for cross-chain USDC transfers
- document Circle setup and chain mapping
- test mock transfer flow and receipt generation

## Testing
- `python -m unittest seibill.tests.test_cctp_bridge`

------
