### PR TITLE
Add reward automation tooling and hook adapter

### DIFF
--- a/contracts/src/rewards/MultiRewardHookAdapter.sol
+++ b/contracts/src/rewards/MultiRewardHookAdapter.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+interface IMultiRewardDistributor {
+    function updateMarketBorrowIndexAndDisburseBorrowerRewards(
+        address tToken,
+        address borrower,
+        bool autoClaim
+    ) external;
+
+    function updateMarketSupplyIndexAndDisburseSupplierRewards(
+        address tToken,
+        address supplier,
+        bool autoClaim
+    ) external;
+}
+
+/// @title MultiRewardHookAdapter
+/// @notice Helper contract that forwards borrow/mint lifecycle hooks to a MultiRewardDistributor.
+/// @dev Deploy alongside a Comptroller or hook-enabled market to keep reward indices fresh.
+contract MultiRewardHookAdapter {
+    /// @notice Immutable reference to the rewards distributor.
+    address public immutable distributor;
+
+    error InvalidDistributor();
+
+    constructor(address distributor_) {
+        if (distributor_ == address(0)) revert InvalidDistributor();
+        distributor = distributor_;
+    }
+
+    /// @notice Forward the borrow verify hook to the distributor so borrower rewards stay current.
+    /// @param tToken Address of the market that triggered the hook.
+    /// @param borrower Account whose debt changed.
+    /// @param /* borrowAmount */ uint256 borrowAmount Ignored but preserved for Comptroller signature compatibility.
+    function borrowVerify(address tToken, address borrower, uint256 /* borrowAmount */) external {
+        IMultiRewardDistributor(distributor).updateMarketBorrowIndexAndDisburseBorrowerRewards(
+            tToken,
+            borrower,
+            true
+        );
+    }
+
+    /// @notice Forward the mint verify hook to the distributor so supplier rewards stay current.
+    /// @param tToken Address of the market that triggered the hook.
+    /// @param minter Account whose supply changed.
+    /// @param /* mintAmount */ uint256 mintAmount Ignored but preserved for Comptroller signature compatibility.
+    /// @param /* tokensMinted */ uint256 tokensMinted Ignored but preserved for Comptroller signature compatibility.
+    function mintVerify(address tToken, address minter, uint256 /* mintAmount */, uint256 /* tokensMinted */) external {
+        IMultiRewardDistributor(distributor).updateMarketSupplyIndexAndDisburseSupplierRewards(
+            tToken,
+            minter,
+            true
+        );
+    }
+}

--- a/tools/rewards/README.md
+++ b/tools/rewards/README.md
@@ -1,0 +1,93 @@
+# Reward Automation Toolkit
+
+Utilities for automating MultiRewardDistributor flows on Sei. The toolkit is intentionally modular so it can be wired into cronjobs, serverless workers or custom bots.
+
+## Installation
+
+The scripts rely on [`ethers@6`](https://docs.ethers.org/v6/) and modern Node.js (>= 18). Install dependencies from the project root or inside this directory:
+
+```bash
+npm install ethers
+```
+
+Optionally install [`dotenv`](https://www.npmjs.com/package/dotenv) if you prefer loading environment variables from a file:
+
+```bash
+npm install dotenv
+node --env-file=.env tools/rewards/autoClaimer.mjs --help
+```
+
+## Auto Claimer
+
+```
+node tools/rewards/autoClaimer.mjs \
+  --distributor 0x28BF6D71b6Dc837F56F5afbF1F4A46AaC0B1f31E \
+  --mode both \
+  --loop --interval 120
+```
+
+Environment variables:
+
+- `RPC_URL` – HTTP endpoint for Sei EVM RPC.
+- `PRIVATE_KEY` – Executor wallet private key.
+- Optional overrides `REWARD_DISTRIBUTOR`, `REWARD_USER`.
+
+Flags:
+
+- `--mode` selects `borrow`, `supply` or `both` streams.
+- `--gas-limit` provides a manual gas limit override.
+- `--dry-run` prints planned transactions without broadcasting.
+- `--loop` and `--interval` turn the script into a polling daemon.
+
+## Monitor / Cron Worker
+
+```
+node tools/rewards/monitor.mjs \
+  --distributor 0x28BF6D71b6Dc837F56F5afbF1F4A46AaC0B1f31E \
+  --webhook https://hooks.slack.com/... \
+  --metrics-file ./outstanding.log
+```
+
+This script only needs `RPC_URL`. It collects outstanding rewards, prints a concise summary and optionally ships structured JSON payloads to a webhook or appends them to a metrics file—ideal for `cron`, GitHub Actions, AWS Lambda, or Cloudflare Workers.
+
+`MONITOR_INTERVAL`, `MONITOR_WEBHOOK`, and `MONITOR_METRICS_FILE` can also be used to configure the daemon via environment variables.
+
+## SDK Helper
+
+Importable helpers live in `tools/rewards/sdk/index.mjs`:
+
+```js
+import { createRewardClient } from "./tools/rewards/sdk/index.mjs";
+import { ethers } from "ethers";
+
+const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
+const client = createRewardClient(provider, "0x28BF6D71b6Dc837F56F5afbF1F4A46AaC0B1f31E");
+
+await client.claimAllRewards("0xb2b297eF9449aa0905bC318B3bd258c4804BAd98");
+```
+
+Each method returns an array of transaction promises so you can await confirmations or feed them into a queueing system.
+
+## Configuration Template
+
+Copy `config.example.json` and adjust addresses for local scripts or bots:
+
+```bash
+cp tools/rewards/config.example.json config/rewards.local.json
+```
+
+Use it to hydrate environment variables in CI workflows or runtime configs.
+
+## Smart-Contract Hook Adapter
+
+For protocols that prefer on-chain automation, deploy `contracts/src/rewards/MultiRewardHookAdapter.sol` and wire it into the Comptroller/TToken hook callbacks:
+
+```solidity
+MultiRewardHookAdapter hook = new MultiRewardHookAdapter(0x28BF6D71b6Dc837F56F5afbF1F4A46AaC0B1f31E);
+
+// Comptroller configuration
+comptroller._setBorrowVerify(hook);
+comptroller._setMintVerify(hook);
+```
+
+Borrow and mint lifecycle events now forward to the distributor so indices stay fresh without waiting for off-chain bots.

--- a/tools/rewards/abi/IMultiRewardDistributor.json
+++ b/tools/rewards/abi/IMultiRewardDistributor.json
@@ -1,0 +1,67 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "user", "type": "address" }
+    ],
+    "name": "getOutstandingRewardsForUser",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "tToken", "type": "address" },
+          { "internalType": "address", "name": "rewardToken", "type": "address" },
+          { "internalType": "uint256", "name": "amount", "type": "uint256" },
+          { "internalType": "bool", "name": "isBorrowReward", "type": "bool" }
+        ],
+        "internalType": "struct OutstandingReward[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tToken", "type": "address" },
+      { "internalType": "address", "name": "user", "type": "address" },
+      { "internalType": "bool", "name": "autoClaim", "type": "bool" }
+    ],
+    "name": "disburseBorrowerRewards",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tToken", "type": "address" },
+      { "internalType": "address", "name": "user", "type": "address" },
+      { "internalType": "bool", "name": "autoClaim", "type": "bool" }
+    ],
+    "name": "disburseSupplierRewards",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tToken", "type": "address" },
+      { "internalType": "address", "name": "user", "type": "address" },
+      { "internalType": "bool", "name": "autoClaim", "type": "bool" }
+    ],
+    "name": "updateMarketBorrowIndexAndDisburseBorrowerRewards",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tToken", "type": "address" },
+      { "internalType": "address", "name": "user", "type": "address" },
+      { "internalType": "bool", "name": "autoClaim", "type": "bool" }
+    ],
+    "name": "updateMarketSupplyIndexAndDisburseSupplierRewards",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/tools/rewards/autoClaimer.mjs
+++ b/tools/rewards/autoClaimer.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+import { ethers } from "ethers";
+import { buildSigner, createDistributorContract, mapOutstandingRewards, sleep } from "./lib/distributorClient.mjs";
+
+const USAGE = `
+Usage: node autoClaimer.mjs [options]
+
+Required environment variables:
+  RPC_URL        JSON-RPC endpoint (HTTP)
+  PRIVATE_KEY    Hex encoded private key for the executor wallet
+
+Options:
+  --distributor <address>   Override reward distributor address
+  --user <address>          Claim for a specific address (defaults to signer address)
+  --mode <borrow|supply|both>
+                            Reward streams to claim (default: both)
+  --loop                    Continuously poll for rewards
+  --interval <seconds>      Poll interval when looping (default: 60)
+  --gas-limit <number>      Gas limit hint for disburse transactions
+  --dry-run                 Print actions without sending transactions
+  --help                    Display this message
+`;
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const config = {
+    distributor: process.env.REWARD_DISTRIBUTOR,
+    user: process.env.REWARD_USER,
+    mode: "both",
+    loop: false,
+    interval: 60,
+    dryRun: false,
+  };
+
+  for (let i = 0; i < args.length; ) {
+    const arg = args[i];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        console.log(USAGE);
+        process.exit(0);
+        break;
+      case "--distributor":
+        if (!args[i + 1]) {
+          throw new Error("--distributor requires an address value");
+        }
+        config.distributor = args[i + 1];
+        i += 2;
+        break;
+      case "--user":
+        if (!args[i + 1]) {
+          throw new Error("--user requires an address value");
+        }
+        config.user = args[i + 1];
+        i += 2;
+        break;
+      case "--mode":
+        if (!args[i + 1]) {
+          throw new Error("--mode requires a value");
+        }
+        config.mode = args[i + 1];
+        i += 2;
+        break;
+      case "--loop":
+        config.loop = true;
+        i += 1;
+        break;
+      case "--interval":
+        if (!args[i + 1]) {
+          throw new Error("--interval requires a numeric value");
+        }
+        config.interval = Number(args[i + 1]);
+        i += 2;
+        break;
+      case "--gas-limit":
+        if (!args[i + 1]) {
+          throw new Error("--gas-limit requires a numeric value");
+        }
+        config.gasLimit = BigInt(args[i + 1]);
+        if (config.gasLimit <= 0n) {
+          throw new Error("--gas-limit must be positive");
+        }
+        i += 2;
+        break;
+      case "--dry-run":
+        config.dryRun = true;
+        i += 1;
+        break;
+      default:
+        if (arg.startsWith("-")) {
+          throw new Error(`Unknown flag: ${arg}`);
+        }
+        i += 1;
+        break;
+    }
+  }
+
+  if (!config.distributor) {
+    throw new Error("Missing reward distributor address. Provide --distributor or set REWARD_DISTRIBUTOR env var.");
+  }
+
+  if (!ethers.isAddress(config.distributor)) {
+    throw new Error(`Invalid distributor address provided: ${config.distributor}`);
+  }
+
+  if (config.user && !ethers.isAddress(config.user)) {
+    throw new Error(`Invalid user address provided: ${config.user}`);
+  }
+
+  if (!config.mode || !["borrow", "supply", "both"].includes(config.mode)) {
+    throw new Error("--mode must be one of: borrow, supply, both");
+  }
+
+  if (Number.isNaN(config.interval) || config.interval <= 0) {
+    throw new Error("--interval must be a positive number of seconds");
+  }
+
+  return config;
+}
+
+async function disburseRewards({ distributor, user, rewards, mode, gasLimit, dryRun }) {
+  const shouldClaimBorrow = mode === "borrow" || mode === "both";
+  const shouldClaimSupply = mode === "supply" || mode === "both";
+
+  const txs = [];
+  for (const reward of rewards) {
+    const amount = BigInt(reward.amount);
+    if (amount === 0n) continue;
+
+    const label = reward.isBorrowReward ? "borrow" : "supply";
+    if ((label === "borrow" && !shouldClaimBorrow) || (label === "supply" && !shouldClaimSupply)) {
+      continue;
+    }
+
+    if (dryRun) {
+      console.log(`ℹ️  Dry run: would claim ${ethers.formatUnits(amount)} from ${reward.tToken} (${label})`);
+      continue;
+    }
+
+    const method = reward.isBorrowReward
+      ? "disburseBorrowerRewards"
+      : "disburseSupplierRewards";
+
+    console.log(`🚀 Claiming ${label} rewards for ${user} from ${reward.tToken}...`);
+    const args = [reward.tToken, user, true];
+    if (gasLimit) {
+      args.push({ gasLimit });
+    }
+    const tx = await distributor[method](...args);
+    txs.push(tx.wait());
+  }
+
+  await Promise.all(txs);
+  if (!dryRun && txs.length === 0) {
+    console.log("No claimable rewards for the selected mode.");
+  }
+}
+
+async function main() {
+  const config = parseArgs();
+  const signer = buildSigner({});
+  const account = config.user ?? (await signer.getAddress());
+  const distributor = createDistributorContract(signer, config.distributor);
+
+  do {
+    const outstanding = await distributor.getOutstandingRewardsForUser(account);
+    const rewards = mapOutstandingRewards(outstanding);
+
+    if (rewards.length === 0) {
+      console.log("No rewards returned by distributor.");
+    }
+
+    await disburseRewards({
+      distributor,
+      user: account,
+      rewards,
+      mode: config.mode,
+      gasLimit: config.gasLimit,
+      dryRun: config.dryRun,
+    });
+
+    if (!config.loop) break;
+
+    console.log(`Sleeping for ${config.interval} seconds...`);
+    await sleep(config.interval * 1000);
+  } while (config.loop);
+}
+
+main().catch((error) => {
+  console.error("❌ autoClaimer failed:", error);
+  process.exitCode = 1;
+});

--- a/tools/rewards/config.example.json
+++ b/tools/rewards/config.example.json
@@ -1,0 +1,16 @@
+{
+  "distributor": "0x28BF6D71b6Dc837F56F5afbF1F4A46AaC0B1f31E",
+  "rpcUrl": "https://evm-rpc.arctic-1.seinetwork.io",
+  "accounts": [
+    {
+      "label": "compounder-bot",
+      "address": "0xb2b297eF9449aa0905bC318B3bd258c4804BAd98",
+      "privateKeyEnv": "PRIVATE_KEY"
+    }
+  ],
+  "cron": {
+    "intervalSeconds": 300,
+    "webhook": "https://hooks.slack.com/services/...",
+    "metricsFile": "./outstanding.log"
+  }
+}

--- a/tools/rewards/lib/distributorClient.mjs
+++ b/tools/rewards/lib/distributorClient.mjs
@@ -1,0 +1,59 @@
+import { ethers } from "ethers";
+import distributorAbi from "../abi/IMultiRewardDistributor.json" assert { type: "json" };
+
+/**
+ * Creates a typed MultiRewardDistributor contract instance.
+ * @param {ethers.Signer | ethers.Provider} signerOrProvider
+ * @param {string} distributorAddress
+ */
+export function createDistributorContract(signerOrProvider, distributorAddress) {
+  if (!ethers.isAddress(distributorAddress)) {
+    throw new Error(`Invalid distributor address: ${distributorAddress}`);
+  }
+
+  return new ethers.Contract(distributorAddress, distributorAbi, signerOrProvider);
+}
+
+/**
+ * Resolve a signer from the provided configuration.
+ * @param {{ rpcUrl?: string, privateKey?: string }} config
+ */
+export function buildSigner(config = {}) {
+  const provider = buildProvider(config);
+  const privateKey = config.privateKey ?? process.env.PRIVATE_KEY;
+
+  if (!privateKey) {
+    throw new Error("Missing private key. Provide config.privateKey or set PRIVATE_KEY env var.");
+  }
+
+  return new ethers.Wallet(privateKey, provider);
+}
+
+export function buildProvider(config = {}) {
+  const rpcUrl = config.rpcUrl ?? process.env.RPC_URL;
+
+  if (!rpcUrl) {
+    throw new Error("Missing RPC URL. Provide config.rpcUrl or set RPC_URL env var.");
+  }
+
+  return new ethers.JsonRpcProvider(rpcUrl);
+}
+
+/**
+ * Normalise outstanding reward tuples into friendlier objects.
+ * @param {Array<{ tToken: string, rewardToken: string, amount: bigint, isBorrowReward: boolean }>} rewards
+ */
+export function mapOutstandingRewards(rewards) {
+  return rewards.map((reward) => ({
+    ...reward,
+    amount: BigInt(reward.amount),
+  }));
+}
+
+/**
+ * Simple delay helper.
+ * @param {number} ms
+ */
+export function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/tools/rewards/monitor.mjs
+++ b/tools/rewards/monitor.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import { ethers } from "ethers";
+import { buildProvider, createDistributorContract, mapOutstandingRewards, sleep } from "./lib/distributorClient.mjs";
+
+const USAGE = `
+Usage: node monitor.mjs [options]
+
+Environment variables:
+  RPC_URL                 JSON-RPC endpoint (HTTP)
+
+Options:
+  --distributor <address>   Reward distributor contract address (required)
+  --user <address>          User account to inspect (default: distributor signer)
+  --interval <seconds>      Poll interval (default: 300)
+  --webhook <url>           POST reward snapshots to webhook URL
+  --metrics-file <path>     Append JSON metrics into a file (rotatable via logrotate)
+  --once                    Run a single iteration and exit
+  --help                    Show this message
+`;
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const config = {
+    distributor: process.env.REWARD_DISTRIBUTOR,
+    user: process.env.REWARD_USER,
+    interval: Number(process.env.MONITOR_INTERVAL ?? 300),
+    webhook: process.env.MONITOR_WEBHOOK,
+    metricsFile: process.env.MONITOR_METRICS_FILE,
+    once: false,
+  };
+
+  for (let i = 0; i < args.length; ) {
+    const arg = args[i];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        console.log(USAGE);
+        process.exit(0);
+        break;
+      case "--distributor":
+        if (!args[i + 1]) throw new Error("--distributor requires an address value");
+        config.distributor = args[i + 1];
+        i += 2;
+        break;
+      case "--user":
+        if (!args[i + 1]) throw new Error("--user requires an address value");
+        config.user = args[i + 1];
+        i += 2;
+        break;
+      case "--interval":
+        if (!args[i + 1]) throw new Error("--interval requires a numeric value");
+        config.interval = Number(args[i + 1]);
+        i += 2;
+        break;
+      case "--webhook":
+        if (!args[i + 1]) throw new Error("--webhook requires a URL value");
+        config.webhook = args[i + 1];
+        i += 2;
+        break;
+      case "--metrics-file":
+        if (!args[i + 1]) throw new Error("--metrics-file requires a path");
+        config.metricsFile = args[i + 1];
+        i += 2;
+        break;
+      case "--once":
+        config.once = true;
+        i += 1;
+        break;
+      default:
+        if (arg.startsWith("-")) {
+          throw new Error(`Unknown flag: ${arg}`);
+        }
+        i += 1;
+        break;
+    }
+  }
+
+  if (!config.distributor) {
+    throw new Error("Reward distributor address missing. Provide --distributor or set REWARD_DISTRIBUTOR env var.");
+  }
+
+  if (!ethers.isAddress(config.distributor)) {
+    throw new Error(`Invalid distributor address: ${config.distributor}`);
+  }
+
+  if (config.user && !ethers.isAddress(config.user)) {
+    throw new Error(`Invalid user address: ${config.user}`);
+  }
+
+  if (Number.isNaN(config.interval) || config.interval <= 0) {
+    throw new Error("--interval must be a positive number");
+  }
+
+  return config;
+}
+
+async function emitMetrics(config, snapshot) {
+  if (config.metricsFile) {
+    try {
+      const payload = JSON.stringify(snapshot);
+      await fs.promises.appendFile(config.metricsFile, `${payload}\n`);
+    } catch (error) {
+      console.error("⚠️ Failed to append metrics file:", error);
+    }
+  }
+
+  if (config.webhook) {
+    try {
+      const response = await fetch(config.webhook, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(snapshot),
+      });
+      if (!response.ok) {
+        console.error(`⚠️ Webhook responded with status ${response.status}`);
+      }
+    } catch (error) {
+      console.error("⚠️ Failed to send webhook payload:", error);
+    }
+  }
+}
+
+async function runMonitor(config) {
+  const provider = buildProvider({});
+  const distributor = createDistributorContract(provider, config.distributor);
+  const account = config.user ?? config.distributor;
+
+  do {
+    const startedAt = Date.now();
+    const rewards = mapOutstandingRewards(await distributor.getOutstandingRewardsForUser(account));
+    const summary = rewards.reduce(
+      (acc, reward) => {
+        const key = reward.isBorrowReward ? "borrow" : "supply";
+        acc[key].push(reward);
+        acc.totalValue = acc.totalValue + reward.amount;
+        return acc;
+      },
+      { borrow: [], supply: [], totalValue: 0n }
+    );
+
+    const snapshot = {
+      timestamp: new Date().toISOString(),
+      distributor: config.distributor,
+      user: account,
+      outstandingBorrow: summary.borrow.map((reward) => ({
+        market: reward.tToken,
+        token: reward.rewardToken,
+        amount: reward.amount.toString(),
+      })),
+      outstandingSupply: summary.supply.map((reward) => ({
+        market: reward.tToken,
+        token: reward.rewardToken,
+        amount: reward.amount.toString(),
+      })),
+      totalOutstanding: summary.totalValue.toString(),
+    };
+
+    console.log(
+      `[${snapshot.timestamp}] Borrow rewards: ${summary.borrow.length}, Supply rewards: ${summary.supply.length}, ` +
+        `Total raw amount: ${summary.totalValue.toString()}`
+    );
+    await emitMetrics(config, snapshot);
+
+    if (config.once) break;
+
+    const elapsed = Date.now() - startedAt;
+    const sleepMs = Math.max(0, config.interval * 1000 - elapsed);
+    if (sleepMs > 0) {
+      await sleep(sleepMs);
+    }
+  } while (!config.once);
+}
+
+async function main() {
+  try {
+    const config = parseArgs();
+    await runMonitor(config);
+  } catch (error) {
+    console.error("❌ monitor failed:", error);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/tools/rewards/package.json
+++ b/tools/rewards/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sei-reward-toolkit",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "description": "Automation scripts and SDK helpers for the Sei MultiRewardDistributor",
+  "scripts": {
+    "auto-claim": "node autoClaimer.mjs",
+    "monitor": "node monitor.mjs"
+  },
+  "dependencies": {
+    "ethers": "^6.11.1"
+  }
+}

--- a/tools/rewards/sdk/index.mjs
+++ b/tools/rewards/sdk/index.mjs
@@ -1,0 +1,51 @@
+import { createDistributorContract } from "../lib/distributorClient.mjs";
+
+/**
+ * Build a high-level client that exposes helper methods for interacting with the distributor.
+ * @param {import("ethers").Signer | import("ethers").Provider} signerOrProvider
+ * @param {string} distributorAddress
+ */
+export function createRewardClient(signerOrProvider, distributorAddress) {
+  const distributor = createDistributorContract(signerOrProvider, distributorAddress);
+
+  return {
+    distributor,
+    async claimBorrowerRewards(user, options = {}) {
+      const rewards = await distributor.getOutstandingRewardsForUser(user);
+      const calls = rewards
+        .filter((reward) => reward.isBorrowReward)
+        .map((reward) => callWithOverrides(distributor, "disburseBorrowerRewards", reward, user, options));
+
+      return Promise.all(calls);
+    },
+    async claimSupplierRewards(user, options = {}) {
+      const rewards = await distributor.getOutstandingRewardsForUser(user);
+      const calls = rewards
+        .filter((reward) => !reward.isBorrowReward)
+        .map((reward) => callWithOverrides(distributor, "disburseSupplierRewards", reward, user, options));
+
+      return Promise.all(calls);
+    },
+    async claimAllRewards(user, options = {}) {
+      const rewards = await distributor.getOutstandingRewardsForUser(user);
+      const calls = rewards.map((reward) => {
+        const method = reward.isBorrowReward ? "disburseBorrowerRewards" : "disburseSupplierRewards";
+        return callWithOverrides(distributor, method, reward, user, options);
+      });
+
+      return Promise.all(calls);
+    },
+  };
+}
+
+export { createDistributorContract } from "../lib/distributorClient.mjs";
+
+function callWithOverrides(distributor, method, reward, user, options) {
+  const args = [reward.tToken, user, options.autoClaim ?? true];
+  const overrides = options.overrides ?? {};
+  if (overrides && Object.keys(overrides).length > 0) {
+    args.push(overrides);
+  }
+
+  return distributor[method](...args);
+}


### PR DESCRIPTION
## Summary
- add a modular Node.js reward automation toolkit with auto-claimer, monitor and SDK helpers
- document usage patterns plus provide example config and package manifest for the toolkit
- introduce a MultiRewardHookAdapter solidity helper to forward borrow/mint hooks to the reward distributor

## Testing
- npx --prefix contracts hardhat compile *(fails: registry access forbidden in execution environment)*

------