### PR TITLE
Add proxy reward disbursement tooling and auto claimer CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "sei-chain-scripts",
+  "version": "1.0.0",
+  "private": true,
+  "devDependencies": {
+    "jest": "^30.1.3"
+  },
+  "dependencies": {
+    "ethers": "^6.13.1"
+  }
+}

--- a/scripts/autoClaimer.mjs
+++ b/scripts/autoClaimer.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+import rewards from './rewards/index.js';
+
+function parseArgs(argv) {
+  const result = { _: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) {
+      result._.push(token);
+      continue;
+    }
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (next && !next.startsWith('--')) {
+      result[key] = next;
+      i += 1;
+    } else {
+      result[key] = true;
+    }
+  }
+  return result;
+}
+
+async function runFetchImplementation(options) {
+  const provider = await rewards.getProvider(options.rpc ?? process.env.RPC_URL);
+  const proxy = options.proxy ?? process.env.PROXY_ADDRESS ?? rewards.DEFAULT_PROXY_ADDRESS;
+  const slot = options.slot ?? process.env.IMPLEMENTATION_SLOT ?? rewards.IMPLEMENTATION_SLOT;
+  const implementation = await rewards.fetchImplementationAddress(provider, proxy, slot);
+
+  if (options.json || process.env.JSON_OUTPUT) {
+    console.log(
+      JSON.stringify(
+        {
+          proxy,
+          slot,
+          implementation
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  console.log(`\u{1F9E0} Implementation address: ${implementation}`);
+}
+
+async function runCalldata(options) {
+  const rewardType = options.method ?? options.rewardType ?? options.role ?? options._[0] ?? process.env.METHOD ?? process.env.REWARD_TYPE ?? process.env.ROLE ?? 'borrower';
+  const tToken = options.ttoken ?? options.market ?? options._[1] ?? process.env.TTOKEN;
+  const user = options.user ?? options.account ?? options._[2] ?? process.env.USER;
+  const sendTokensInput = options.sendTokens ?? options.send ?? options._[3] ?? process.env.SEND_TOKENS;
+  const sendTokens = rewards.normalizeBoolean(sendTokensInput, true);
+
+  const calldata = await rewards.encodeDisburseCalldata({
+    rewardType,
+    tToken,
+    user,
+    sendTokens
+  });
+
+  if (options.json || process.env.JSON_OUTPUT) {
+    console.log(
+      JSON.stringify(
+        {
+          method: rewards.getMethodForRewardType(rewardType),
+          proxy: options.proxy ?? process.env.PROXY_ADDRESS ?? rewards.DEFAULT_PROXY_ADDRESS,
+          tToken,
+          user,
+          sendTokens,
+          calldata
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  console.log(`\u{1F517} Calldata: ${calldata}`);
+}
+
+async function runDisburse(options) {
+  const rewardType = options.method ?? options.rewardType ?? options.role ?? options._[0] ?? process.env.REWARD_TYPE ?? process.env.ROLE ?? 'borrower';
+  const tToken = options.ttoken ?? options.market ?? options._[1] ?? process.env.TTOKEN;
+  const user = options.user ?? options.account ?? options._[2] ?? process.env.USER;
+  const sendTokensInput = options.sendTokens ?? options.send ?? options._[3] ?? process.env.SEND_TOKENS;
+  const sendTokens = rewards.normalizeBoolean(sendTokensInput, true);
+  const waitForReceipt = !rewards.normalizeBoolean(options.noWait ?? process.env.NO_WAIT, false);
+
+  const proxyAddress = options.proxy ?? process.env.PROXY_ADDRESS ?? rewards.DEFAULT_PROXY_ADDRESS;
+  const provider = await rewards.getProvider(options.rpc ?? process.env.RPC_URL);
+  const signer = await rewards.getSigner(options.privateKey ?? process.env.PRIVATE_KEY, provider);
+
+  const { tx, receipt } = await rewards.disburseRewards({
+    signer,
+    proxyAddress,
+    rewardType,
+    tToken,
+    user,
+    sendTokens,
+    waitForReceipt
+  });
+
+  if (options.json || process.env.JSON_OUTPUT) {
+    console.log(
+      JSON.stringify(
+        {
+          proxy: proxyAddress,
+          rewardType: rewards.getMethodForRewardType(rewardType),
+          tToken,
+          user,
+          sendTokens,
+          txHash: tx.hash,
+          blockNumber: receipt?.blockNumber ?? null
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  console.log(`\u{1F4E7} Submitted TX: ${tx.hash}`);
+  if (waitForReceipt && receipt) {
+    console.log(`\u{2705} Confirmed in block: ${receipt.blockNumber}`);
+  } else if (!waitForReceipt) {
+    console.log('\u{26A0}\u{FE0F} Waiting skipped (noWait flag set).');
+  }
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/autoClaimer.mjs <command> [options]\n`);
+  console.log('Commands:');
+  console.log('  fetch-implementation   Resolve proxy implementation address.');
+  console.log('  disburse               Submit a borrower/supplier reward disbursement.');
+  console.log('  calldata               Generate calldata for multisig or governance.');
+  console.log('\nCommon options:');
+  console.log('  --proxy <address>      Override proxy address (defaults to Sei rewards proxy).');
+  console.log('  --rpc <url>            JSON-RPC endpoint (or set RPC_URL).');
+  console.log('  --json                 Emit structured JSON instead of text output.');
+  console.log('\nDisburse options:');
+  console.log('  --rewardType <type>    borrower (default) or supplier.');
+  console.log('  --ttoken <address>     Target market address.');
+  console.log('  --user <address>       Account receiving rewards.');
+  console.log('  --sendTokens <bool>    Whether to transfer accrued tokens (default true).');
+  console.log('  --noWait               Do not wait for transaction confirmation.');
+  console.log('\nCalldata options mirror disburse options.');
+}
+
+async function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  const [commandRaw = 'help', ...positionals] = parsed._;
+  parsed._ = positionals;
+  const command = commandRaw.toLowerCase();
+
+  if (parsed.help || command === '--help') {
+    printHelp();
+    return;
+  }
+
+  if (command === 'fetch-implementation' || command === 'fetch' || command === 'implementation') {
+    await runFetchImplementation(parsed);
+    return;
+  }
+
+  if (command === 'disburse') {
+    await runDisburse(parsed);
+    return;
+  }
+
+  if (command === 'calldata') {
+    await runCalldata(parsed);
+    return;
+  }
+
+  printHelp();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/disburseReward.js
+++ b/scripts/disburseReward.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+'use strict';
+
+const rewards = require('./rewards');
+
+async function main() {
+  const proxyAddress = process.env.PROXY_ADDRESS ?? rewards.DEFAULT_PROXY_ADDRESS;
+  const rewardType = process.env.REWARD_TYPE ?? process.env.ROLE ?? 'borrower';
+  const tToken = process.env.TTOKEN;
+  const user = process.env.USER;
+  const sendTokens = rewards.normalizeBoolean(process.env.SEND_TOKENS, true);
+  const waitForReceipt = !rewards.normalizeBoolean(process.env.NO_WAIT, false);
+
+  const provider = await rewards.getProvider(process.env.RPC_URL);
+  const signer = await rewards.getSigner(process.env.PRIVATE_KEY, provider);
+  const { tx, receipt } = await rewards.disburseRewards({
+    signer,
+    proxyAddress,
+    rewardType,
+    tToken,
+    user,
+    sendTokens,
+    waitForReceipt
+  });
+
+  console.log(`\u{1F4E7} Submitted TX: ${tx.hash}`);
+  if (waitForReceipt && receipt) {
+    console.log(`\u{2705} Confirmed in block: ${receipt.blockNumber}`);
+  } else {
+    console.log('\u{26A0}\u{FE0F} Waiting skipped (NO_WAIT set).');
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/disburseWithImplementationCheck.js
+++ b/scripts/disburseWithImplementationCheck.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+'use strict';
+
+const rewards = require('./rewards');
+
+async function main() {
+  const proxyAddress = process.env.PROXY_ADDRESS ?? rewards.DEFAULT_PROXY_ADDRESS;
+  const slot = process.env.IMPLEMENTATION_SLOT ?? rewards.IMPLEMENTATION_SLOT;
+  const rewardType = process.env.REWARD_TYPE ?? process.env.ROLE ?? 'borrower';
+  const sendTokens = rewards.normalizeBoolean(process.env.SEND_TOKENS, true);
+  const waitForReceipt = !rewards.normalizeBoolean(process.env.NO_WAIT, false);
+
+  const provider = await rewards.getProvider(process.env.RPC_URL);
+  const implementation = await rewards.fetchImplementationAddress(provider, proxyAddress, slot);
+  console.log(`\u{1F9E0} Impl address: ${implementation}`);
+
+  const signer = await rewards.getSigner(process.env.PRIVATE_KEY, provider);
+  const { tx, receipt } = await rewards.disburseRewards({
+    signer,
+    proxyAddress,
+    rewardType,
+    tToken: process.env.TTOKEN,
+    user: process.env.USER,
+    sendTokens,
+    waitForReceipt
+  });
+
+  console.log(`\u{1F4E7} Submitted: ${tx.hash}`);
+  if (waitForReceipt && receipt) {
+    console.log(`\u{2705} Done in block: ${receipt.blockNumber}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/genCalldata.js
+++ b/scripts/genCalldata.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+'use strict';
+
+const rewards = require('./rewards');
+
+function parseArgs(argv) {
+  const result = { _: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) {
+      result._.push(token);
+      continue;
+    }
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (next && !next.startsWith('--')) {
+      result[key] = next;
+      i += 1;
+    } else {
+      result[key] = true;
+    }
+  }
+  return result;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const rewardType = args.method ?? args.rewardType ?? args.role ?? args._[0] ?? process.env.METHOD ?? process.env.REWARD_TYPE ?? process.env.ROLE ?? 'borrower';
+  const tToken = args.ttoken ?? args.market ?? args._[1] ?? process.env.TTOKEN;
+  const user = args.user ?? args.account ?? args._[2] ?? process.env.USER;
+  const sendTokensInput = args.sendTokens ?? args.send ?? args._[3] ?? process.env.SEND_TOKENS;
+  const sendTokens = rewards.normalizeBoolean(sendTokensInput, true);
+
+  const calldata = await rewards.encodeDisburseCalldata({
+    rewardType,
+    tToken,
+    user,
+    sendTokens
+  });
+
+  if (args.json || process.env.JSON_OUTPUT) {
+    console.log(
+      JSON.stringify(
+        {
+          method: rewards.getMethodForRewardType(rewardType),
+          proxy: process.env.PROXY_ADDRESS ?? rewards.DEFAULT_PROXY_ADDRESS,
+          tToken,
+          user,
+          sendTokens,
+          calldata
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  console.log(`\u{1F517} Calldata: ${calldata}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/getImplementation.js
+++ b/scripts/getImplementation.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+'use strict';
+
+const rewards = require('./rewards');
+
+async function main() {
+  const provider = await rewards.getProvider(process.env.RPC_URL);
+  const proxyAddress = process.env.PROXY_ADDRESS ?? rewards.DEFAULT_PROXY_ADDRESS;
+  const slot = process.env.IMPLEMENTATION_SLOT ?? rewards.IMPLEMENTATION_SLOT;
+  const implementation = await rewards.fetchImplementationAddress(provider, proxyAddress, slot);
+  console.log(`\u{1F9E0} Implementation address: ${implementation}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/rewards/index.js
+++ b/scripts/rewards/index.js
@@ -1,0 +1,155 @@
+'use strict';
+
+const DEFAULT_PROXY_ADDRESS = '0x28BF6D71b6Dc837F56F5afbF1F4A46AaC0B1f31E';
+const IMPLEMENTATION_SLOT = '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc';
+const DISTRIBUTOR_ABI = [
+  'function disburseSupplierRewards(address,address,bool)',
+  'function disburseBorrowerRewards(address,address,bool)'
+];
+
+let cachedEthers;
+
+async function loadEthers() {
+  if (!cachedEthers) {
+    const mod = await import('ethers');
+    cachedEthers = mod.ethers ?? mod.default ?? mod;
+  }
+  return cachedEthers;
+}
+
+function ensure(value, message) {
+  if (value === undefined || value === null || value === '') {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function normalizeBoolean(value, fallback = false) {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (['true', 't', 'yes', 'y', '1'].includes(normalized)) {
+    return true;
+  }
+  if (['false', 'f', 'no', 'n', '0'].includes(normalized)) {
+    return false;
+  }
+  throw new Error(`Unable to interpret boolean value from "${value}"`);
+}
+
+async function getProvider(rpcUrl) {
+  const ethers = await loadEthers();
+  const url = ensure(rpcUrl ?? process.env.RPC_URL, 'RPC URL is required (set RPC_URL)');
+  return new ethers.JsonRpcProvider(url);
+}
+
+async function getSigner(privateKey, provider) {
+  const ethers = await loadEthers();
+  const key = ensure(privateKey ?? process.env.PRIVATE_KEY, 'Private key is required (set PRIVATE_KEY)');
+  if (!provider) {
+    provider = await getProvider();
+  }
+  return new ethers.Wallet(key, provider);
+}
+
+async function fetchImplementationAddress(provider, proxyAddress, slot = IMPLEMENTATION_SLOT) {
+  const ethers = await loadEthers();
+  const normalizedProxy = ethers.getAddress(proxyAddress ?? DEFAULT_PROXY_ADDRESS);
+  const raw = await provider.getStorageAt(normalizedProxy, slot);
+  if (!raw) {
+    throw new Error(`No storage value returned for slot ${slot}`);
+  }
+  const stripped = raw.replace(/^0x/i, '').padStart(64, '0');
+  const impl = '0x' + stripped.slice(-40);
+  return ethers.getAddress(impl);
+}
+
+function getMethodForRewardType(rewardType) {
+  const normalized = (rewardType ?? '').toString().toLowerCase();
+  if (normalized === 'supplier' || normalized === 'suppliers') {
+    return 'disburseSupplierRewards';
+  }
+  if (normalized === 'borrower' || normalized === 'borrowers') {
+    return 'disburseBorrowerRewards';
+  }
+  if (normalized === 'disbursesupplierrewards') {
+    return 'disburseSupplierRewards';
+  }
+  if (normalized === 'disburseborrowerrewards') {
+    return 'disburseBorrowerRewards';
+  }
+  throw new Error('Reward type must be either "borrower" or "supplier"');
+}
+
+async function getDistributorContract(signerOrProvider, proxyAddress = DEFAULT_PROXY_ADDRESS) {
+  const ethers = await loadEthers();
+  const normalizedProxy = ethers.getAddress(proxyAddress);
+  return new ethers.Contract(normalizedProxy, DISTRIBUTOR_ABI, signerOrProvider);
+}
+
+async function disburseRewards({
+  signer,
+  provider,
+  proxyAddress = DEFAULT_PROXY_ADDRESS,
+  rewardType = 'borrower',
+  tToken,
+  user,
+  sendTokens = true,
+  waitForReceipt = true
+}) {
+  if (!signer) {
+    if (!provider) {
+      provider = await getProvider();
+    }
+    signer = await getSigner(undefined, provider);
+  }
+  const ethers = await loadEthers();
+  const contract = await getDistributorContract(signer, proxyAddress);
+  const method = getMethodForRewardType(rewardType);
+  const targetToken = ethers.getAddress(ensure(tToken, 'Market (TTOKEN) address is required'));
+  const userAddress = ethers.getAddress(ensure(user, 'User address is required'));
+  const shouldSend = normalizeBoolean(sendTokens, true);
+  const tx = await contract[method](targetToken, userAddress, shouldSend);
+  if (!waitForReceipt) {
+    return { tx };
+  }
+  const receipt = await tx.wait();
+  return { tx, receipt };
+}
+
+async function encodeDisburseCalldata({
+  rewardType = 'borrower',
+  tToken,
+  user,
+  sendTokens = true
+}) {
+  const ethers = await loadEthers();
+  const iface = new ethers.Interface(DISTRIBUTOR_ABI);
+  const method = getMethodForRewardType(rewardType);
+  const targetToken = ethers.getAddress(ensure(tToken, 'Market (TTOKEN) address is required'));
+  const userAddress = ethers.getAddress(ensure(user, 'User address is required'));
+  const shouldSend = normalizeBoolean(sendTokens, true);
+  return iface.encodeFunctionData(method, [targetToken, userAddress, shouldSend]);
+}
+
+module.exports = {
+  DEFAULT_PROXY_ADDRESS,
+  IMPLEMENTATION_SLOT,
+  DISTRIBUTOR_ABI,
+  loadEthers,
+  getProvider,
+  getSigner,
+  fetchImplementationAddress,
+  getDistributorContract,
+  disburseRewards,
+  encodeDisburseCalldata,
+  normalizeBoolean,
+  getMethodForRewardType
+};


### PR DESCRIPTION
## Summary
- add reusable reward helper module backed by ethers for interacting with the Sei rewards proxy
- provide standalone scripts to fetch the proxy implementation, disburse rewards, and produce multisig calldata
- wire a CLI-oriented autoClaimer entry point for GitHub bot or pipeline integrations

## Testing
- npm install *(fails: registry returned 403 Forbidden in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf2caa0548322969ed98636e79217