### PR TITLE
feat: scaffold reward sdk package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ integration_test/dapp_tests/artifacts
 
 # Compressed archives and release bundles
 *.zip
+
+# reward sdk build artifacts
+sdk/dist/

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,0 +1,46 @@
+# @web3plus/reward-utils
+
+Typed helper SDK for interacting with Sei reward distributor contracts. The package wraps
+common read and write flows, validates configuration, and exposes utilities that are safe to
+compose from bot frameworks or dashboards.
+
+## Installation
+
+```bash
+npm install @web3plus/reward-utils
+```
+
+## Quick start
+
+```ts
+import { RewardClient, parseRewardConfig } from "@web3plus/reward-utils";
+
+const config = parseRewardConfig({
+  rpcUrl: "https://sei.example.org",
+  distributorAddress: "0xDistributor",
+});
+
+const client = new RewardClient(config);
+const markets = await client.getMarketsWithRewards("0xUser");
+console.log("Reward markets", markets);
+```
+
+## Features
+
+- ⚙️ Strongly-typed configuration parsing and validation
+- 🔄 Batched reward lookups with `getMarketsWithRewards`
+- ⛽ Gas estimation helpers through `estimateClaimGas`
+- 🧹 Balance sweeping via `sweepTokensTo`
+- 🧠 Reusable agent-facing types for automation layers
+
+## Building
+
+```bash
+npm run build
+```
+
+The compiled output is emitted into `dist/` and includes both JavaScript and type definitions.
+
+## License
+
+MIT

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@web3plus/reward-utils",
+  "version": "0.1.0",
+  "description": "Typed SDK helpers for interacting with Sei reward distributors",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./types": "./dist/types.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "sei",
+    "rewards",
+    "sdk",
+    "defi"
+  ],
+  "author": "Sei Labs",
+  "license": "MIT",
+  "dependencies": {
+    "ethers": "^6.11.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.5",
+    "typescript": "^5.4.2"
+  }
+}

--- a/sdk/src/abiRegistry.ts
+++ b/sdk/src/abiRegistry.ts
@@ -1,0 +1,21 @@
+export const rewardDistributorAbi = [
+  "function getOutstandingRewardsForUser(address user) view returns ((address tToken, address rewardToken, uint256 amount, uint8 rewardType)[])",
+  "function disburseSupplierRewards(address user, address market)",
+  "function disburseBorrowerRewards(address user, address market)",
+];
+
+export const erc20Abi = [
+  "function balanceOf(address owner) view returns (uint256)",
+  "function transfer(address to, uint256 amount) returns (bool)",
+];
+
+export type AbiRegistryKey = "rewardDistributor" | "erc20";
+
+const abiRegistry: Record<AbiRegistryKey, readonly string[]> = {
+  rewardDistributor: rewardDistributorAbi,
+  erc20: erc20Abi,
+};
+
+export function getAbi(key: AbiRegistryKey): readonly string[] {
+  return abiRegistry[key];
+}

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -1,0 +1,171 @@
+import { Contract, getAddress, isAddress } from "ethers";
+import { erc20Abi, rewardDistributorAbi } from "./abiRegistry.js";
+import type {
+  ClaimEstimate,
+  ClaimEstimateDetail,
+  EstimateClaimGasOptions,
+  RewardClientConfig,
+  RewardMode,
+  RewardStream,
+  SweepOptions,
+  SweepResult,
+} from "./types.js";
+
+const CLAIM_METHODS: Record<RewardMode, "disburseSupplierRewards" | "disburseBorrowerRewards"> = {
+  supply: "disburseSupplierRewards",
+  borrow: "disburseBorrowerRewards",
+};
+
+function normalizeMode(value: unknown): RewardMode {
+  if (typeof value === "string") {
+    const normalized = value.toLowerCase();
+    if (normalized === "borrow") {
+      return "borrow";
+    }
+    if (normalized === "supply") {
+      return "supply";
+    }
+    const numeric = Number.parseInt(normalized, 10);
+    if (!Number.isNaN(numeric)) {
+      return numeric === 1 ? "borrow" : "supply";
+    }
+  }
+  if (typeof value === "number") {
+    return value === 1 ? "borrow" : "supply";
+  }
+  if (typeof value === "bigint") {
+    return value === 1n ? "borrow" : "supply";
+  }
+  return "supply";
+}
+
+function toBigInt(value: unknown): bigint {
+  if (typeof value === "bigint") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return BigInt(Math.trunc(value));
+  }
+  if (typeof value === "string") {
+    return BigInt(value);
+  }
+  return 0n;
+}
+
+function normalizeRewardRecord(record: any): RewardStream {
+  const market = getAddress(record?.tToken ?? record?.market ?? record?.[0]);
+  const rewardToken = getAddress(record?.rewardToken ?? record?.token ?? record?.[1]);
+  const amount = toBigInt(record?.amount ?? record?.totalAccrued ?? record?.[2]);
+  const mode = normalizeMode(record?.rewardType ?? record?.mode ?? record?.[3]);
+  return { market, rewardToken, amount, mode };
+}
+
+function ensureAddress(address: string, field: string): string {
+  if (!isAddress(address)) {
+    throw new Error(`Invalid address for ${field}: ${address}`);
+  }
+  return getAddress(address);
+}
+
+export class RewardClient {
+  private readonly config: RewardClientConfig;
+  private readonly distributor: Contract;
+
+  constructor(config: RewardClientConfig) {
+    this.config = config;
+    const runner = config.signer ?? config.runner ?? config.provider;
+    this.distributor = new Contract(config.distributorAddress, rewardDistributorAbi, runner);
+  }
+
+  async getOutstandingRewards(user: string): Promise<RewardStream[]> {
+    const normalizedUser = ensureAddress(user, "user");
+    const response = await this.distributor.getOutstandingRewardsForUser(normalizedUser);
+    if (!Array.isArray(response)) {
+      return [];
+    }
+    return response.map((entry: any) => normalizeRewardRecord(entry));
+  }
+
+  async getMarketsWithRewards(user: string): Promise<string[]> {
+    const rewards = await this.getOutstandingRewards(user);
+    const markets = new Set<string>();
+    for (const reward of rewards) {
+      if (reward.amount > 0n) {
+        markets.add(reward.market);
+      }
+    }
+    return Array.from(markets);
+  }
+
+  async estimateClaimGas(user: string, options: EstimateClaimGasOptions = {}): Promise<ClaimEstimate> {
+    const normalizedUser = ensureAddress(user, "user");
+    const rewards = await this.getOutstandingRewards(normalizedUser);
+    const filtered = options.mode ? rewards.filter((reward) => reward.mode === options.mode) : rewards;
+
+    let totalGas: bigint | undefined;
+    const details: ClaimEstimateDetail[] = [];
+    for (const reward of filtered) {
+      const method = CLAIM_METHODS[reward.mode];
+      const estimator = (this.distributor.estimateGas as Record<string, Function | undefined>)[method];
+      if (typeof estimator !== "function") {
+        details.push({
+          ...reward,
+          gasLimit: undefined,
+          error: `Gas estimator not available for method ${method}`,
+        });
+        continue;
+      }
+      try {
+        const gasLimit = await estimator.call(this.distributor.estimateGas, normalizedUser, reward.market);
+        const gasBigInt = toBigInt(gasLimit);
+        totalGas = totalGas === undefined ? gasBigInt : totalGas + gasBigInt;
+        details.push({ ...reward, gasLimit: gasBigInt });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        details.push({ ...reward, error: message });
+      }
+    }
+
+    return {
+      user: normalizedUser,
+      totalGas,
+      details,
+    };
+  }
+
+  async sweepTokensTo(target: string, options: SweepOptions = {}): Promise<SweepResult> {
+    if (!this.config.signer) {
+      throw new Error("A signer is required to sweep tokens");
+    }
+    const signer = this.config.signer;
+    const normalizedTarget = ensureAddress(target, "target");
+    const from = ensureAddress(
+      options.from ?? this.config.sweep?.from ?? (await signer.getAddress()),
+      "sweep.from"
+    );
+    const tokens = (options.tokens ?? this.config.sweep?.tokens ?? []).map((token, index) =>
+      ensureAddress(token, `sweep.tokens[${index}]`)
+    );
+    const waitForReceipt = options.waitForReceipt ?? true;
+
+    const transfers = [] as SweepResult["transfers"];
+    for (const token of tokens) {
+      const contract = new Contract(token, erc20Abi, signer);
+      const balance: bigint = await contract.balanceOf(from);
+      if (balance === 0n) {
+        continue;
+      }
+      const tx = await contract.transfer(normalizedTarget, balance);
+      if (waitForReceipt) {
+        await tx.wait();
+      }
+      transfers.push({ token, amount: balance, transactionHash: tx.hash });
+    }
+
+    return {
+      from,
+      target: normalizedTarget,
+      transfers,
+    };
+  }
+}

--- a/sdk/src/config.ts
+++ b/sdk/src/config.ts
@@ -1,0 +1,105 @@
+import { JsonRpcProvider, getAddress, isAddress } from "ethers";
+import type { Provider } from "ethers";
+import type { RewardClientConfig, RewardConfigInput, SweepConfig } from "./types.js";
+
+function buildProvider(input: RewardConfigInput): Provider {
+  if (input.provider) {
+    return input.provider;
+  }
+  if (!input.rpcUrl) {
+    throw new Error("Reward configuration requires either a provider or rpcUrl");
+  }
+  return new JsonRpcProvider(input.rpcUrl);
+}
+
+function normalizeAddress(address: string, field: string): string {
+  if (!isAddress(address)) {
+    throw new Error(`Invalid address for ${field}: ${address}`);
+  }
+  return getAddress(address);
+}
+
+function normalizeSweepConfig(sweep?: Partial<SweepConfig> | null): SweepConfig | undefined {
+  if (!sweep) {
+    return undefined;
+  }
+  const tokens = (sweep.tokens ?? []).map((token, index) =>
+    normalizeAddress(token, `sweep.tokens[${index}]`)
+  );
+  return {
+    tokens,
+    from: sweep.from ? normalizeAddress(sweep.from, "sweep.from") : undefined,
+    unwrapWsei: sweep.unwrapWsei ?? false,
+  };
+}
+
+export function parseRewardConfig(input: RewardConfigInput): RewardClientConfig {
+  if (!input.distributorAddress) {
+    throw new Error("Reward configuration requires distributorAddress");
+  }
+  const provider = buildProvider(input);
+  const distributorAddress = normalizeAddress(input.distributorAddress, "distributorAddress");
+  return {
+    provider,
+    distributorAddress,
+    signer: input.signer,
+    sweep: normalizeSweepConfig(input.sweep ?? undefined),
+  };
+}
+
+export interface EnvConfigShape {
+  REWARD_RPC_URL?: string;
+  RPC_URL?: string;
+  SEI_RPC_URL?: string;
+  REWARD_DISTRIBUTOR_ADDRESS?: string;
+  DISTRIBUTOR_ADDRESS?: string;
+  REWARD_SWEEP_TOKENS?: string;
+  SWEEP_TOKENS?: string;
+  REWARD_SWEEP_FROM?: string;
+  SWEEP_FROM?: string;
+  REWARD_SWEEP_UNWRAP_WSEI?: string;
+  SWEEP_UNWRAP_WSEI?: string;
+}
+
+function parseTokens(value?: string): string[] {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function parseBoolean(value?: string): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return value === "1" || value.toLowerCase() === "true";
+}
+
+export function parseRewardConfigFromEnv(env: EnvConfigShape = {}): RewardClientConfig {
+  const rpcUrl = env.REWARD_RPC_URL ?? env.RPC_URL ?? env.SEI_RPC_URL;
+  const distributorAddress = env.REWARD_DISTRIBUTOR_ADDRESS ?? env.DISTRIBUTOR_ADDRESS;
+  if (!rpcUrl) {
+    throw new Error("Environment config missing RPC URL (REWARD_RPC_URL or RPC_URL)");
+  }
+  if (!distributorAddress) {
+    throw new Error(
+      "Environment config missing distributor address (REWARD_DISTRIBUTOR_ADDRESS or DISTRIBUTOR_ADDRESS)"
+    );
+  }
+  const sweepTokens = parseTokens(env.REWARD_SWEEP_TOKENS ?? env.SWEEP_TOKENS);
+  const sweepFrom = env.REWARD_SWEEP_FROM ?? env.SWEEP_FROM;
+  const unwrapWsei = parseBoolean(env.REWARD_SWEEP_UNWRAP_WSEI ?? env.SWEEP_UNWRAP_WSEI);
+
+  return parseRewardConfig({
+    rpcUrl,
+    distributorAddress,
+    sweep: {
+      tokens: sweepTokens,
+      from: sweepFrom,
+      unwrapWsei: unwrapWsei ?? false,
+    },
+  });
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./abiRegistry.js";
+export * from "./client.js";
+export * from "./config.js";
+export * from "./types.js";

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -1,0 +1,77 @@
+import type { ContractRunner, Provider, Signer } from "ethers";
+
+export type RewardMode = "supply" | "borrow";
+
+export interface RewardStream {
+  market: string;
+  rewardToken: string;
+  amount: bigint;
+  mode: RewardMode;
+}
+
+export interface RewardAgent {
+  id: string;
+  address: string;
+  type: RewardMode | "compounder";
+  autoClaim?: boolean;
+  tags?: string[];
+}
+
+export interface ClaimEstimateDetail {
+  market: string;
+  rewardToken: string;
+  amount: bigint;
+  mode: RewardMode;
+  gasLimit?: bigint;
+  error?: string;
+}
+
+export interface ClaimEstimate {
+  user: string;
+  totalGas?: bigint;
+  details: ClaimEstimateDetail[];
+}
+
+export interface SweepTransferResult {
+  token: string;
+  amount: bigint;
+  transactionHash: string;
+}
+
+export interface SweepResult {
+  from: string;
+  target: string;
+  transfers: SweepTransferResult[];
+}
+
+export interface SweepConfig {
+  tokens: string[];
+  from?: string;
+  unwrapWsei?: boolean;
+}
+
+export interface RewardClientConfig {
+  provider: Provider;
+  distributorAddress: string;
+  signer?: Signer;
+  sweep?: SweepConfig;
+  runner?: ContractRunner;
+}
+
+export interface RewardConfigInput {
+  rpcUrl?: string;
+  provider?: Provider;
+  signer?: Signer;
+  distributorAddress: string;
+  sweep?: Partial<SweepConfig> | null;
+}
+
+export interface EstimateClaimGasOptions {
+  mode?: RewardMode;
+}
+
+export interface SweepOptions {
+  tokens?: string[];
+  waitForReceipt?: boolean;
+  from?: string;
+}

--- a/sdk/tsconfig.json
+++ b/sdk/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- scaffold a TypeScript reward SDK package with dedicated client, config, type, and ABI registry modules
- add npm metadata, exports, and documentation for @web3plus/reward-utils consumers

## Testing
- `npm run build` *(fails: missing ethers typings because registry access is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf2f5d5488322afcc8c368014fbe4