### PR TITLE
feat: add AI governance scribe toolkit

### DIFF
--- a/tools/governance/README.md
+++ b/tools/governance/README.md
@@ -1,0 +1,63 @@
+# Codex AI Governance Scribe
+
+`aiScribe.mjs` is the command-line orchestrator for the "full AI governance rewrite". It analyses reward indices, backlog risk,
+and emission schedules to generate an actionable governance plan for Sei reward markets.
+
+## Features
+
+- Pulls live reward backlog data from the `MultiRewardDistributor` (when not in `--offline` mode).
+- Correlates market metadata (baseline emissions, utilization targets, backlog thresholds) from a JSON config file.
+- Forecasts emission coverage across configurable horizons and highlights systemic shortfalls.
+- Generates per-market operational playbooks (NodeBot call flows) and governance proposal scaffolds.
+- Supports text, Markdown, or JSON output for downstream automation and reporting.
+
+## Usage
+
+```bash
+# Install dependencies (from this directory)
+npm install
+
+# Generate a plan using the example config (offline seed data only)
+node aiScribe.mjs --offline --format markdown
+
+# Run against live chain data
+RPC_URL=https://sei.example.org \
+REWARD_DISTRIBUTOR=0xYourDistributor \
+node aiScribe.mjs \
+  --config ./templates/governance-config.example.json \
+  --accounts 0xYourAccount,0xAnotherAccount \
+  --forecast-horizon 45 \
+  --format text \
+  --export ./plan.txt
+```
+
+Environment variables mirror the CLI flags (`GOVERNANCE_CONFIG`, `GOVERNANCE_FORMAT`, etc.) so the tool can be dropped into
+cron jobs or the NodeBot agent.
+
+## Configuration Schema
+
+The config file (see [`templates/governance-config.example.json`](./templates/governance-config.example.json)) provides:
+
+- **`network`**: metadata for display.
+- **`distributor`**: default contract address (overridden by CLI/env when needed).
+- **`rewardToken`**: symbol + decimals for formatting and math.
+- **`accounts`**: optional default account list when CLI `--accounts` is omitted.
+- **`global`**: systemic thresholds (buffer days, max backlog before emergency sync).
+- **`emissionSchedule`**: rolling emission projections (per-day totals over epoch windows).
+- **`markets`**: array of market descriptors, each with optional `borrow`/`supply` stream configs:
+  - `baselineEmissionPerDay`: expected emissions per stream (numeric or string, token units).
+  - `maxBacklogDays`: threshold for alerting/escalation.
+  - `seedOutstanding`: fallback backlog estimate for offline planning.
+  - `boostOnUnderUtilization`: flag to auto-suggest emission boosts when utilization is below target.
+  - `notes`: extra guidance for the generated report.
+
+## Output
+
+Depending on the format you choose, `aiScribe` returns:
+
+- **text**: console-friendly action report with per-market breakdowns.
+- **markdown**: drop-in documentation for governance calls or dashboards.
+- **json**: structured data for further automation (e.g. feeding into bots or dashboards).
+
+Each recommendation contains severity, operational steps, and governance scaffolding so that human reviewers (or autonomous
+agents) can immediately execute the plan.

--- a/tools/governance/aiScribe.mjs
+++ b/tools/governance/aiScribe.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import {
+  normaliseConfig,
+  mergeOutstandingRewards,
+  buildGovernancePlan,
+  formatPlanAsText,
+  formatPlanAsMarkdown,
+} from "./lib/aiPlanner.mjs";
+import { isAddress, normalizeAddress } from "./lib/tokenMath.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DEFAULT_CONFIG_PATH = path.resolve(__dirname, "templates/governance-config.example.json");
+
+const USAGE = `
+Usage: node aiScribe.mjs [options]
+
+Options:
+  --config <path>             Path to governance config JSON (default: templates/governance-config.example.json)
+  --distributor <address>     Reward distributor contract address
+  --accounts <addr1,addr2>    Comma-separated list of accounts to analyse
+  --forecast-horizon <days>   Forecast window in days (default: 30)
+  --format <text|markdown|json>
+                             Output format (default: text)
+  --export <path>             Write the plan to a file
+  --rpc <url>                 Override RPC URL (defaults to RPC_URL env)
+  --offline                   Skip on-chain queries and rely on config seed data
+  --help                      Show this message
+`;
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const config = {
+    configPath: process.env.GOVERNANCE_CONFIG ?? DEFAULT_CONFIG_PATH,
+    distributor: process.env.REWARD_DISTRIBUTOR ?? null,
+    accounts: process.env.GOVERNANCE_ACCOUNTS ?? null,
+    forecastHorizon: process.env.GOVERNANCE_FORECAST ? Number(process.env.GOVERNANCE_FORECAST) : 30,
+    format: process.env.GOVERNANCE_FORMAT ?? "text",
+    exportPath: process.env.GOVERNANCE_EXPORT ?? null,
+    rpcUrl: process.env.GOVERNANCE_RPC ?? null,
+    offline: false,
+  };
+
+  for (let i = 0; i < args.length; ) {
+    const arg = args[i];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        console.log(USAGE);
+        process.exit(0);
+        break;
+      case "--config":
+        config.configPath = args[i + 1];
+        if (!config.configPath) {
+          throw new Error("--config requires a path value");
+        }
+        i += 2;
+        break;
+      case "--distributor":
+        config.distributor = args[i + 1];
+        if (!config.distributor) {
+          throw new Error("--distributor requires an address value");
+        }
+        i += 2;
+        break;
+      case "--accounts":
+        config.accounts = args[i + 1];
+        if (!config.accounts) {
+          throw new Error("--accounts requires a value");
+        }
+        i += 2;
+        break;
+      case "--forecast-horizon":
+        config.forecastHorizon = Number(args[i + 1]);
+        if (!Number.isFinite(config.forecastHorizon) || config.forecastHorizon <= 0) {
+          throw new Error("--forecast-horizon must be a positive number");
+        }
+        i += 2;
+        break;
+      case "--format":
+        config.format = args[i + 1];
+        if (!config.format) {
+          throw new Error("--format requires a value");
+        }
+        i += 2;
+        break;
+      case "--export":
+        config.exportPath = args[i + 1];
+        if (!config.exportPath) {
+          throw new Error("--export requires a path value");
+        }
+        i += 2;
+        break;
+      case "--rpc":
+        config.rpcUrl = args[i + 1];
+        if (!config.rpcUrl) {
+          throw new Error("--rpc requires a URL");
+        }
+        i += 2;
+        break;
+      case "--offline":
+        config.offline = true;
+        i += 1;
+        break;
+      default:
+        if (arg.startsWith("-")) {
+          throw new Error(`Unknown flag: ${arg}`);
+        }
+        i += 1;
+        break;
+    }
+  }
+
+  if (!config.format || !["text", "markdown", "json"].includes(config.format)) {
+    throw new Error("--format must be one of: text, markdown, json");
+  }
+
+  return config;
+}
+
+async function loadJson(pathname) {
+  const contents = await readFile(pathname, "utf8");
+  return JSON.parse(contents);
+}
+
+function parseAccounts(input, configAccounts = []) {
+  const values = [];
+  if (typeof input === "string" && input.length > 0) {
+    values.push(...input.split(","));
+  }
+  if (Array.isArray(input)) {
+    values.push(...input);
+  }
+  if (Array.isArray(configAccounts)) {
+    values.push(...configAccounts);
+  }
+  const seen = new Set();
+  const accounts = [];
+  for (const raw of values) {
+    const candidate = raw?.trim();
+    if (!candidate) continue;
+    if (!isAddress(candidate)) {
+      throw new Error(`Invalid account address provided: ${candidate}`);
+    }
+    const normalised = normalizeAddress(candidate);
+    if (seen.has(normalised)) continue;
+    seen.add(normalised);
+    accounts.push(normalised);
+  }
+  return accounts;
+}
+
+async function main() {
+  const args = parseArgs();
+  const configPath = path.resolve(args.configPath);
+  let rawConfig = {};
+  try {
+    rawConfig = await loadJson(configPath);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      console.warn(`⚠️  Config file not found at ${configPath}. Proceeding with minimal defaults.`);
+    } else {
+      throw error;
+    }
+  }
+
+  const normalisedConfig = normaliseConfig(rawConfig);
+  const distributorAddress = args.distributor ?? normalisedConfig.distributor;
+  if (!args.offline) {
+    if (!distributorAddress) {
+      throw new Error("Distributor address is required. Provide via --distributor, config file, or REWARD_DISTRIBUTOR env var.");
+    }
+    if (!isAddress(distributorAddress)) {
+      throw new Error(`Invalid distributor address: ${distributorAddress}`);
+    }
+  }
+
+  const accounts = parseAccounts(args.accounts, normalisedConfig.accounts);
+  let outstanding = new Map();
+
+  if (!args.offline) {
+    const { buildProvider, createDistributorContract, mapOutstandingRewards } = await import("../rewards/lib/distributorClient.mjs");
+    const provider = buildProvider({ rpcUrl: args.rpcUrl ?? undefined });
+    const distributor = createDistributorContract(provider, distributorAddress);
+    if (accounts.length === 0) {
+      console.warn("⚠️  No accounts provided. Planner will only use seedOutstanding values from config.");
+    }
+    for (const account of accounts) {
+      const rewards = await distributor.getOutstandingRewardsForUser(account);
+      const mapped = mapOutstandingRewards(rewards);
+      outstanding = mergeOutstandingRewards(outstanding, mapped);
+    }
+  }
+
+  const plan = buildGovernancePlan({
+    config: { ...normalisedConfig, distributor: distributorAddress },
+    outstandingByStream: outstanding,
+    accounts,
+    horizonDays: args.forecastHorizon,
+  });
+
+  let output;
+  if (args.format === "json") {
+    output = JSON.stringify(plan, null, 2);
+  } else if (args.format === "markdown") {
+    output = formatPlanAsMarkdown(plan);
+  } else {
+    output = formatPlanAsText(plan);
+  }
+
+  console.log(output);
+
+  if (args.exportPath) {
+    const exportTarget = path.resolve(args.exportPath);
+    await writeFile(exportTarget, output + (args.format === "json" ? "" : "\n"), "utf8");
+    console.log(`✅ Plan written to ${exportTarget}`);
+  }
+}
+
+main().catch((error) => {
+  console.error("❌ aiScribe failed:", error);
+  process.exitCode = 1;
+});

--- a/tools/governance/lib/aiPlanner.mjs
+++ b/tools/governance/lib/aiPlanner.mjs
@@ -1,0 +1,574 @@
+import { formatUnits, parseUnits } from "./tokenMath.mjs";
+
+function toNumber(value, fallback = null) {
+  if (value === undefined || value === null) return fallback;
+  const num = typeof value === "string" ? Number(value) : Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  return num;
+}
+
+function toBoolean(value) {
+  if (value === undefined || value === null) return false;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+  }
+  return false;
+}
+
+function parseAmount(value, decimals) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number") {
+    return parseUnits(value.toString(), decimals);
+  }
+  if (typeof value === "string") {
+    if (value.startsWith("0x")) {
+      return BigInt(value);
+    }
+    return parseUnits(value, decimals);
+  }
+  throw new Error(`Unsupported amount value: ${value}`);
+}
+
+function computeBacklogDays(outstanding, baselinePerDay, decimals) {
+  if (!baselinePerDay || baselinePerDay === 0n) return null;
+  if (!outstanding || outstanding === 0n) return 0;
+  const outstandingFloat = Number.parseFloat(formatUnits(outstanding, decimals));
+  const baselineFloat = Number.parseFloat(formatUnits(baselinePerDay, decimals));
+  if (!Number.isFinite(outstandingFloat) || !Number.isFinite(baselineFloat) || baselineFloat === 0) {
+    return null;
+  }
+  return outstandingFloat / baselineFloat;
+}
+
+function formatPercent(value) {
+  if (value === null || value === undefined) return "n/a";
+  return `${(value * 100).toFixed(2)}%`;
+}
+
+function normaliseStream(stream, decimals, type) {
+  if (!stream) return null;
+  const baseline = stream.baselineEmissionPerDay !== undefined ? parseAmount(stream.baselineEmissionPerDay, decimals) : null;
+  const seedOutstanding = stream.seedOutstanding !== undefined ? parseAmount(stream.seedOutstanding, decimals) : null;
+  const maxBacklogDays = toNumber(stream.maxBacklogDays);
+  return {
+    type,
+    baselinePerDay: baseline,
+    maxBacklogDays: maxBacklogDays !== null ? maxBacklogDays : null,
+    seedOutstanding,
+    boostOnUnderUtilization: toBoolean(stream.boostOnUnderUtilization ?? stream.meta?.boostOnUnderUtilization),
+    notes: stream.notes ?? null,
+  };
+}
+
+function normalisePolicy(policy) {
+  if (!policy) {
+    return {
+      currentUtilization: null,
+      targetUtilization: null,
+      governors: [],
+      notes: null,
+    };
+  }
+  const governors = Array.isArray(policy.governors)
+    ? policy.governors.filter((addr) => typeof addr === "string" && addr.length > 0)
+    : [];
+  return {
+    currentUtilization: toNumber(policy.currentUtilization),
+    targetUtilization: toNumber(policy.targetUtilization),
+    governors,
+    notes: policy.notes ?? null,
+  };
+}
+
+function normaliseMarket(market, decimals) {
+  const address = typeof market.address === "string" ? market.address : null;
+  const lower = address ? address.toLowerCase() : null;
+  return {
+    address,
+    addressLc: lower,
+    label: market.label ?? (address ? `Market ${address}` : "Unknown Market"),
+    borrow: normaliseStream(market.borrow, decimals, "borrow"),
+    supply: normaliseStream(market.supply, decimals, "supply"),
+    policy: normalisePolicy(market.policy),
+    tags: Array.isArray(market.tags) ? market.tags.filter((tag) => typeof tag === "string") : [],
+  };
+}
+
+function normaliseScheduleEntry(entry, decimals) {
+  if (!entry) return null;
+  const days = toNumber(entry.days);
+  if (!Number.isFinite(days) || days <= 0) {
+    return null;
+  }
+  const emissionPerDay = entry.emissionPerDay !== undefined ? parseAmount(entry.emissionPerDay, decimals) : null;
+  return {
+    label: entry.label ?? "Epoch",
+    days,
+    emissionPerDay,
+  };
+}
+
+export function normaliseConfig(raw = {}) {
+  const decimals = raw.rewardToken?.decimals !== undefined ? Number(raw.rewardToken.decimals) : 18;
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > 30) {
+    throw new Error(`Invalid reward token decimals: ${raw.rewardToken?.decimals}`);
+  }
+  const markets = Array.isArray(raw.markets)
+    ? raw.markets.map((market) => normaliseMarket(market, decimals))
+    : [];
+  const schedule = Array.isArray(raw.emissionSchedule)
+    ? raw.emissionSchedule.map((entry) => normaliseScheduleEntry(entry, decimals)).filter(Boolean)
+    : [];
+  const accounts = Array.isArray(raw.accounts)
+    ? raw.accounts.filter((addr) => typeof addr === "string" && addr.length > 0)
+    : [];
+  return {
+    distributor: raw.distributor ?? null,
+    rewardToken: {
+      symbol: raw.rewardToken?.symbol ?? "TOKEN",
+      decimals,
+    },
+    accounts,
+    markets,
+    emissionSchedule: schedule,
+    network: raw.network ?? null,
+    global: {
+      bufferDays: toNumber(raw.global?.bufferDays),
+      maxSystemBacklogDays: toNumber(raw.global?.maxSystemBacklogDays),
+    },
+  };
+}
+
+export function mergeOutstandingRewards(existingMap, rewards) {
+  const map = new Map(existingMap ?? []);
+  for (const reward of rewards) {
+    const key = `${reward.tToken.toLowerCase()}:${reward.isBorrowReward ? "borrow" : "supply"}`;
+    const entry = map.get(key) ?? { amount: 0n, tToken: reward.tToken, isBorrowReward: reward.isBorrowReward };
+    entry.amount = entry.amount + BigInt(reward.amount);
+    map.set(key, entry);
+  }
+  return map;
+}
+
+function determineSeverity(backlogDays, threshold, fallbackCritical) {
+  if (backlogDays === null) return "unknown";
+  if (backlogDays === 0) return "healthy";
+  const limit = threshold ?? fallbackCritical;
+  if (!limit) {
+    if (backlogDays > 7) return "critical";
+    if (backlogDays > 3) return "warning";
+    return "healthy";
+  }
+  if (backlogDays >= limit * 1.5) return "critical";
+  if (backlogDays > limit) return "warning";
+  return "healthy";
+}
+
+function computeEmissionInsights(schedule, decimals, horizonDays, totalOutstanding, totalBaseline) {
+  if (!schedule || schedule.length === 0) {
+    return null;
+  }
+  let remaining = horizonDays;
+  let cumulative = 0n;
+  const breakdown = [];
+  for (const entry of schedule) {
+    if (remaining <= 0) break;
+    const days = Math.min(remaining, entry.days ?? 0);
+    const emissionPerDay = entry.emissionPerDay ?? 0n;
+    const emitted = emissionPerDay * BigInt(days);
+    cumulative += emitted;
+    breakdown.push({
+      label: entry.label,
+      days,
+      emissionPerDay: emissionPerDay.toString(),
+      totalEmission: emitted.toString(),
+    });
+    remaining -= days;
+  }
+  const outstandingFloat = Number.parseFloat(formatUnits(totalOutstanding ?? 0n, decimals));
+  const emissionFloat = Number.parseFloat(formatUnits(cumulative, decimals));
+  const baselineFloat = totalBaseline && totalBaseline > 0n
+    ? Number.parseFloat(formatUnits(totalBaseline, decimals))
+    : null;
+  const coverageDays = baselineFloat && baselineFloat > 0 ? emissionFloat / baselineFloat : null;
+  return {
+    projectedEmission: cumulative.toString(),
+    projectedEmissionFormatted: emissionFloat.toFixed(6),
+    outstandingCoverageRatio: emissionFloat > 0 ? outstandingFloat / emissionFloat : null,
+    coverageDays,
+    breakdown,
+    shortfall: emissionFloat < outstandingFloat,
+  };
+}
+
+export function buildGovernancePlan({ config, outstandingByStream, accounts, horizonDays = 30 }) {
+  const plan = {
+    generatedAt: new Date().toISOString(),
+    distributor: config.distributor,
+    rewardToken: config.rewardToken,
+    network: config.network,
+    accounts,
+    summary: {
+      totalOutstanding: { raw: "0", formatted: "0" },
+      totalBaselinePerDay: { raw: "0", formatted: "0" },
+      systemBacklogDays: null,
+      systemSeverity: "unknown",
+      emissionForecast: null,
+    },
+    markets: [],
+    unknownStreams: [],
+    globalRecommendations: [],
+  };
+
+  const decimals = config.rewardToken.decimals;
+  const consumedKeys = new Set();
+  let totalOutstanding = 0n;
+  let totalBaseline = 0n;
+
+  for (const market of config.markets) {
+    const marketPlan = {
+      address: market.address,
+      label: market.label,
+      tags: market.tags,
+      policy: market.policy,
+      streams: [],
+    };
+
+    for (const type of ["borrow", "supply"]) {
+      const streamCfg = market[type];
+      if (!streamCfg) continue;
+      const key = `${market.addressLc ?? ""}:${type}`;
+      const outstandingEntry = key.trim() ? outstandingByStream.get(key) : undefined;
+      if (outstandingEntry) {
+        consumedKeys.add(key);
+      }
+      const outstanding = outstandingEntry?.amount ?? streamCfg.seedOutstanding ?? 0n;
+      const formattedOutstanding = formatUnits(outstanding, decimals);
+      const backlogDays = computeBacklogDays(outstanding, streamCfg.baselinePerDay ?? 0n, decimals);
+      const severity = determineSeverity(backlogDays, streamCfg.maxBacklogDays, config.global.maxSystemBacklogDays);
+
+      totalOutstanding += outstanding;
+      if (streamCfg.baselinePerDay) {
+        totalBaseline += streamCfg.baselinePerDay;
+      }
+
+      const recommendations = [];
+      if (backlogDays !== null && streamCfg.maxBacklogDays !== null && backlogDays > streamCfg.maxBacklogDays) {
+        const method = type === "borrow"
+          ? "updateMarketBorrowIndexAndDisburseBorrowerRewards"
+          : "updateMarketSupplyIndexAndDisburseSupplierRewards";
+        const severityLevel = backlogDays >= streamCfg.maxBacklogDays * 1.5 ? "critical" : "warning";
+        const operations = accounts && accounts.length > 0
+          ? accounts.map((account) => ({
+              label: `${market.label} ${type} sync for ${account}`,
+              type: "contractCall",
+              contract: config.distributor,
+              method,
+              args: [market.address, account, true],
+            }))
+          : [];
+        recommendations.push({
+          severity: severityLevel,
+          message: `Backlog of ${backlogDays.toFixed(2)} days exceeds threshold (${streamCfg.maxBacklogDays}). Trigger on-chain index sync and auto-claim loop.`,
+          operations,
+          governance: {
+            type: "operational",
+            description: `Authorize NodeBot to execute ${method} on ${market.label} (${type}) until backlog < ${streamCfg.maxBacklogDays} days.`,
+          },
+        });
+      }
+
+      if (
+        streamCfg.boostOnUnderUtilization &&
+        market.policy?.targetUtilization !== null &&
+        market.policy?.currentUtilization !== null &&
+        market.policy.targetUtilization > market.policy.currentUtilization
+      ) {
+        const delta = market.policy.targetUtilization - market.policy.currentUtilization;
+        const severityLevel = delta > 0.1 ? "warning" : "info";
+        recommendations.push({
+          severity: severityLevel,
+          message: `Utilization ${formatPercent(market.policy.currentUtilization)} below target ${formatPercent(market.policy.targetUtilization)}. Boost ${type} rewards to close the gap.`,
+          governance: {
+            type: "governanceProposal",
+            title: `${market.label}: Adjust ${type} emission multiplier`,
+            description: `Increase ${type} emission multiplier by ~${(delta * 100).toFixed(1)}% to steer utilization toward target.`,
+            actions: [
+              {
+                type: "call",
+                contract: config.distributor,
+                method: "configureEmissionRate",
+                args: [market.address, type, "<newEmissionRate>"],
+                notes: "Replace <newEmissionRate> with calculated target before submission.",
+              },
+            ],
+          },
+        });
+      }
+
+      marketPlan.streams.push({
+        type,
+        outstanding: { raw: outstanding.toString(), formatted: formattedOutstanding },
+        backlogDays,
+        severity,
+        recommendations,
+        notes: streamCfg.notes,
+      });
+    }
+
+    plan.markets.push(marketPlan);
+  }
+
+  for (const [key, entry] of outstandingByStream.entries()) {
+    if (consumedKeys.has(key)) continue;
+    plan.unknownStreams.push({
+      key,
+      tToken: entry.tToken,
+      type: entry.isBorrowReward ? "borrow" : "supply",
+      outstanding: {
+        raw: entry.amount.toString(),
+        formatted: formatUnits(entry.amount, decimals),
+      },
+    });
+    totalOutstanding += entry.amount;
+  }
+
+  plan.summary.totalOutstanding = {
+    raw: totalOutstanding.toString(),
+    formatted: formatUnits(totalOutstanding, decimals),
+  };
+  plan.summary.totalBaselinePerDay = {
+    raw: totalBaseline.toString(),
+    formatted: formatUnits(totalBaseline, decimals),
+  };
+  plan.summary.systemBacklogDays = computeBacklogDays(totalOutstanding, totalBaseline, decimals);
+  plan.summary.systemSeverity = determineSeverity(
+    plan.summary.systemBacklogDays,
+    config.global.maxSystemBacklogDays,
+    config.global.maxSystemBacklogDays,
+  );
+
+  plan.summary.emissionForecast = computeEmissionInsights(
+    config.emissionSchedule,
+    decimals,
+    horizonDays,
+    totalOutstanding,
+    totalBaseline,
+  );
+
+  if (
+    config.global.maxSystemBacklogDays !== null &&
+    plan.summary.systemBacklogDays !== null &&
+    plan.summary.systemBacklogDays > config.global.maxSystemBacklogDays
+  ) {
+    plan.globalRecommendations.push({
+      severity: "critical",
+      message: `System backlog ${plan.summary.systemBacklogDays.toFixed(2)} days exceeds max ${config.global.maxSystemBacklogDays}. Escalate to emergency sync.`,
+      governance: {
+        type: "operational",
+        description: "Engage NodeBot high-frequency mode and authorize additional relayers until backlog clears.",
+      },
+    });
+  }
+
+  if (plan.summary.emissionForecast?.shortfall) {
+    plan.globalRecommendations.push({
+      severity: "warning",
+      message: "Projected emissions over the forecast horizon are insufficient to cover outstanding rewards.",
+      governance: {
+        type: "governanceProposal",
+        title: "Top-up reward emission budget",
+        description: "Submit proposal to replenish distributor reserves or adjust emission weights to avoid depletion.",
+      },
+    });
+  }
+
+  if (config.global.bufferDays && plan.summary.systemBacklogDays !== null && plan.summary.systemBacklogDays > config.global.bufferDays) {
+    plan.globalRecommendations.push({
+      severity: "warning",
+      message: `Backlog exceeds configured buffer of ${config.global.bufferDays} days. Schedule governance review.`,
+      governance: {
+        type: "review",
+        description: "Add agenda item for next governance call to review reward velocities and buffer targets.",
+      },
+    });
+  }
+
+  return plan;
+}
+
+function formatRecommendation(rec) {
+  const parts = [`[${rec.severity.toUpperCase()}] ${rec.message}`];
+  if (rec.operations && rec.operations.length > 0) {
+    parts.push(`  • Operations: ${rec.operations.length} step(s).`);
+  }
+  if (rec.governance?.title) {
+    parts.push(`  • Proposal: ${rec.governance.title}`);
+  } else if (rec.governance?.description) {
+    parts.push(`  • Governance: ${rec.governance.description}`);
+  }
+  return parts.join("\n");
+}
+
+export function formatPlanAsText(plan) {
+  const lines = [];
+  const symbol = plan.rewardToken.symbol ?? "TOKEN";
+  lines.push(`AI Governance Plan for ${symbol} Emissions`);
+  lines.push("=".repeat(lines[0].length));
+  lines.push(`Generated: ${plan.generatedAt}`);
+  if (plan.network?.name) {
+    lines.push(`Network: ${plan.network.name}`);
+  }
+  if (plan.distributor) {
+    lines.push(`Distributor: ${plan.distributor}`);
+  }
+  if (plan.accounts?.length) {
+    lines.push(`Accounts analysed: ${plan.accounts.join(", ")}`);
+  }
+  lines.push("");
+  lines.push(`Total outstanding: ${plan.summary.totalOutstanding.formatted} ${symbol}`);
+  if (plan.summary.totalBaselinePerDay.raw !== "0") {
+    lines.push(`Baseline emission / day: ${plan.summary.totalBaselinePerDay.formatted} ${symbol}`);
+  }
+  if (plan.summary.systemBacklogDays !== null) {
+    lines.push(`System backlog: ${plan.summary.systemBacklogDays.toFixed(2)} days (${plan.summary.systemSeverity})`);
+  }
+  if (plan.summary.emissionForecast) {
+    lines.push(
+      `Projected emission (next window): ${plan.summary.emissionForecast.projectedEmissionFormatted} ${symbol} ` +
+        `(shortfall: ${plan.summary.emissionForecast.shortfall ? "yes" : "no"})`,
+    );
+  }
+  if (plan.globalRecommendations.length > 0) {
+    lines.push("");
+    lines.push("Global Recommendations:");
+    for (const rec of plan.globalRecommendations) {
+      lines.push(`- ${formatRecommendation(rec)}`);
+    }
+  }
+
+  for (const market of plan.markets) {
+    lines.push("");
+    lines.push(`Market: ${market.label}${market.tags.length ? ` [${market.tags.join(", ")}]` : ""}`);
+    if (market.address) {
+      lines.push(`  Address: ${market.address}`);
+    }
+    if (market.policy?.currentUtilization !== null && market.policy?.targetUtilization !== null) {
+      lines.push(
+        `  Utilization: ${formatPercent(market.policy.currentUtilization)} (target ${formatPercent(market.policy.targetUtilization)})`,
+      );
+    }
+    for (const stream of market.streams) {
+      lines.push(`  Stream: ${stream.type}`);
+      lines.push(`    Outstanding: ${stream.outstanding.formatted} ${symbol}`);
+      if (stream.backlogDays !== null) {
+        lines.push(`    Backlog: ${stream.backlogDays.toFixed(2)} days (${stream.severity})`);
+      }
+      if (stream.notes) {
+        lines.push(`    Notes: ${stream.notes}`);
+      }
+      if (stream.recommendations.length === 0) {
+        lines.push("    Recommendations: maintain current settings.");
+      } else {
+        lines.push("    Recommendations:");
+        for (const rec of stream.recommendations) {
+          const formatted = formatRecommendation(rec).split("\n");
+          for (const line of formatted) {
+            lines.push(`      - ${line}`);
+          }
+        }
+      }
+    }
+  }
+
+  if (plan.unknownStreams.length > 0) {
+    lines.push("");
+    lines.push("Unmapped reward streams detected:");
+    for (const entry of plan.unknownStreams) {
+      lines.push(
+        `  - ${entry.key} :: ${entry.outstanding.formatted} ${symbol} outstanding (mark in config to include in planning)`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function formatPlanAsMarkdown(plan) {
+  const symbol = plan.rewardToken.symbol ?? "TOKEN";
+  const lines = [];
+  lines.push(`# AI Governance Plan for ${symbol} Emissions`);
+  lines.push(`_Generated: ${plan.generatedAt}_`);
+  if (plan.network?.name) {
+    lines.push(`- **Network:** ${plan.network.name}`);
+  }
+  if (plan.distributor) {
+    lines.push(`- **Distributor:** \`${plan.distributor}\``);
+  }
+  if (plan.accounts?.length) {
+    lines.push(`- **Accounts analysed:** ${plan.accounts.map((a) => `\`${a}\``).join(", ")}`);
+  }
+  lines.push(`- **Total outstanding:** ${plan.summary.totalOutstanding.formatted} ${symbol}`);
+  if (plan.summary.totalBaselinePerDay.raw !== "0") {
+    lines.push(`- **Baseline emission / day:** ${plan.summary.totalBaselinePerDay.formatted} ${symbol}`);
+  }
+  if (plan.summary.systemBacklogDays !== null) {
+    lines.push(
+      `- **System backlog:** ${plan.summary.systemBacklogDays.toFixed(2)} days (${plan.summary.systemSeverity})`,
+    );
+  }
+  if (plan.summary.emissionForecast) {
+    lines.push(
+      `- **Projected emission (window):** ${plan.summary.emissionForecast.projectedEmissionFormatted} ${symbol} ` +
+        `(shortfall: ${plan.summary.emissionForecast.shortfall ? "yes" : "no"})`,
+    );
+  }
+  if (plan.globalRecommendations.length > 0) {
+    lines.push("\n## Global Recommendations");
+    for (const rec of plan.globalRecommendations) {
+      lines.push(`- ${formatRecommendation(rec)}`);
+    }
+  }
+
+  for (const market of plan.markets) {
+    lines.push(`\n## ${market.label}`);
+    if (market.address) {
+      lines.push(`- Address: \`${market.address}\``);
+    }
+    if (market.policy?.currentUtilization !== null && market.policy?.targetUtilization !== null) {
+      lines.push(
+        `- Utilization: ${formatPercent(market.policy.currentUtilization)} (target ${formatPercent(market.policy.targetUtilization)})`,
+      );
+    }
+    for (const stream of market.streams) {
+      lines.push(`\n### ${stream.type.toUpperCase()} Stream`);
+      lines.push(`- Outstanding: ${stream.outstanding.formatted} ${symbol}`);
+      if (stream.backlogDays !== null) {
+        lines.push(`- Backlog: ${stream.backlogDays.toFixed(2)} days (${stream.severity})`);
+      }
+      if (stream.notes) {
+        lines.push(`- Notes: ${stream.notes}`);
+      }
+      if (stream.recommendations.length === 0) {
+        lines.push("- Recommendations: Maintain current settings.");
+      } else {
+        lines.push("- Recommendations:");
+        for (const rec of stream.recommendations) {
+          lines.push(`  - ${formatRecommendation(rec)}`);
+        }
+      }
+    }
+  }
+
+  if (plan.unknownStreams.length > 0) {
+    lines.push("\n## Unknown Reward Streams");
+    for (const entry of plan.unknownStreams) {
+      lines.push(`- ${entry.key}: ${entry.outstanding.formatted} ${symbol}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/tools/governance/lib/tokenMath.mjs
+++ b/tools/governance/lib/tokenMath.mjs
@@ -1,0 +1,89 @@
+const ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/;
+
+export function isAddress(value) {
+  if (typeof value !== "string") return false;
+  return ADDRESS_REGEX.test(value.trim());
+}
+
+export function normalizeAddress(value) {
+  if (!isAddress(value)) {
+    throw new Error(`Invalid address: ${value}`);
+  }
+  const normalised = value.startsWith("0x") ? value : `0x${value}`;
+  return normalised.toLowerCase();
+}
+
+function bigTen(exp) {
+  if (exp < 0) {
+    throw new Error("Negative decimal precision is not supported");
+  }
+  let result = 1n;
+  for (let i = 0; i < exp; i += 1) {
+    result *= 10n;
+  }
+  return result;
+}
+
+export function parseUnits(value, decimals) {
+  if (typeof decimals !== "number" || !Number.isInteger(decimals) || decimals < 0) {
+    throw new Error(`Invalid decimals value: ${decimals}`);
+  }
+  if (typeof value === "bigint") {
+    return value;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new Error("Cannot parse non-finite number");
+    }
+    value = value.toString();
+  }
+  if (typeof value !== "string") {
+    throw new Error(`Unsupported amount type: ${typeof value}`);
+  }
+  if (value.startsWith("0x") || value.startsWith("-0x")) {
+    return BigInt(value);
+  }
+  let raw = value.trim();
+  let negative = false;
+  if (raw.startsWith("-")) {
+    negative = true;
+    raw = raw.slice(1);
+  }
+  if (!/^\d*(\.\d*)?$/.test(raw)) {
+    throw new Error(`Invalid decimal string: ${value}`);
+  }
+  let [integer = "0", fraction = ""] = raw.split(".");
+  if (integer === "") integer = "0";
+  if (fraction.length > decimals) {
+    fraction = fraction.slice(0, decimals);
+  }
+  const paddedFraction = (fraction + "0".repeat(decimals)).slice(0, decimals);
+  const base = BigInt(integer) * bigTen(decimals);
+  const frac = paddedFraction ? BigInt(paddedFraction) : 0n;
+  let result = base + frac;
+  if (negative) {
+    result = -result;
+  }
+  return result;
+}
+
+export function formatUnits(value, decimals) {
+  if (typeof decimals !== "number" || !Number.isInteger(decimals) || decimals < 0) {
+    throw new Error(`Invalid decimals value: ${decimals}`);
+  }
+  let bigintValue = typeof value === "bigint" ? value : BigInt(value);
+  const negative = bigintValue < 0n;
+  if (negative) {
+    bigintValue = -bigintValue;
+  }
+  const base = bigTen(decimals);
+  const integerPart = bigintValue / base;
+  const fractionPart = bigintValue % base;
+  let fraction = fractionPart.toString().padStart(decimals, "0");
+  fraction = fraction.replace(/0+$/, "");
+  const sign = negative ? "-" : "";
+  if (fraction.length === 0) {
+    return `${sign}${integerPart.toString()}.0`;
+  }
+  return `${sign}${integerPart.toString()}.${fraction}`;
+}

--- a/tools/governance/package.json
+++ b/tools/governance/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sei-governance-scribe",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "description": "AI-assisted governance planning toolkit for Sei rewards",
+  "scripts": {
+    "plan": "node aiScribe.mjs"
+  },
+  "dependencies": {
+    "ethers": "^6.11.1"
+  }
+}

--- a/tools/governance/templates/governance-config.example.json
+++ b/tools/governance/templates/governance-config.example.json
@@ -1,0 +1,76 @@
+{
+  "network": {
+    "name": "Sei Devnet"
+  },
+  "distributor": "0x0000000000000000000000000000000000000000",
+  "rewardToken": {
+    "symbol": "WSEI",
+    "decimals": 18
+  },
+  "accounts": [
+    "0x1111111111111111111111111111111111111111",
+    "0x2222222222222222222222222222222222222222"
+  ],
+  "global": {
+    "bufferDays": 3,
+    "maxSystemBacklogDays": 7
+  },
+  "emissionSchedule": [
+    {
+      "label": "Epoch 12",
+      "days": 14,
+      "emissionPerDay": "25000"
+    },
+    {
+      "label": "Epoch 13",
+      "days": 30,
+      "emissionPerDay": "21000"
+    }
+  ],
+  "markets": [
+    {
+      "address": "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "label": "Sei / USDC Lending",
+      "tags": ["core", "priority"],
+      "policy": {
+        "currentUtilization": 0.52,
+        "targetUtilization": 0.70,
+        "notes": "Usage dipped after rate hike."
+      },
+      "borrow": {
+        "baselineEmissionPerDay": "1800",
+        "maxBacklogDays": 2,
+        "seedOutstanding": "5200",
+        "boostOnUnderUtilization": true
+      },
+      "supply": {
+        "baselineEmissionPerDay": "950",
+        "maxBacklogDays": 3,
+        "seedOutstanding": "1200",
+        "notes": "Supplier backlog minimal."
+      }
+    },
+    {
+      "address": "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+      "label": "Sei / WETH Vault",
+      "tags": ["expansion"],
+      "policy": {
+        "currentUtilization": 0.31,
+        "targetUtilization": 0.55,
+        "notes": "Vault still bootstrapping."
+      },
+      "borrow": {
+        "baselineEmissionPerDay": "900",
+        "maxBacklogDays": 4,
+        "seedOutstanding": "4600",
+        "boostOnUnderUtilization": true,
+        "notes": "Consider temporary boost via governance."
+      },
+      "supply": {
+        "baselineEmissionPerDay": "400",
+        "maxBacklogDays": 5,
+        "seedOutstanding": "800"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add an aiScribe CLI to generate governance playbooks with live or offline reward data
- implement planner, token math helpers, and a sample configuration for AI-driven recommendations
- document usage and package metadata for the new governance toolkit

## Testing
- node tools/governance/aiScribe.mjs --offline --format text


------
https://chatgpt.com/codex/tasks/task_e_68cdefa1daf48322858ed8e623510b05