### PR TITLE
Skip PR comment step when not on pull requests

### DIFF
--- a/.github/workflows/x402.yml
+++ b/.github/workflows/x402.yml
@@ -76,6 +76,11 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            if (!context.payload.pull_request) {
+              core.info('No pull request payload found; skipping comment creation.');
+              return;
+            }
+
             const fs = require('fs');
             const owed = fs.readFileSync('owed.txt', 'utf8');
             const banner = [
@@ -91,13 +96,6 @@ jobs:
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: prNumber,
-              body: banner
-            });
-
-            const prNumber = context.payload.pull_request.number;
-            await github.rest.issues.createComment({
-              ...context.repo,
               issue_number: prNumber,
               body: banner
             });


### PR DESCRIPTION
## Summary
- skip the PR comment script when the workflow runs without pull request context
- remove the duplicate comment invocation left over from the original script

## Testing
- node - <<'EOF' ...

------
https://chatgpt.com/codex/tasks/task_e_68cff40a368c8322ba4ca2210d57d8d6