### PR TITLE
Ensure owed table exists before PR comment

### DIFF
--- a/.github/workflows/x402.yml
+++ b/.github/workflows/x402.yml
@@ -71,6 +71,36 @@ jobs:
         run: |
           until [ "$(cat build/generated/launch.complete | wc -l)" -eq 4 ]; do sleep 10; done
           sleep 10
+      - name: Generate owed table
+        run: |
+          set -euo pipefail
+          if [ -f owed.txt ]; then
+            echo "owed.txt already present. Skipping generation."
+            exit 0
+          fi
+
+          RECEIPTS=""
+          if [ -f ./x402/receipts.json ]; then
+            RECEIPTS=./x402/receipts.json
+          elif [ -f ./.x402/receipts.json ]; then
+            RECEIPTS=./.x402/receipts.json
+          fi
+
+          if [ -n "$RECEIPTS" ]; then
+            if bash x402.sh "$RECEIPTS" > owed.txt; then
+              echo "Generated owed.txt from $RECEIPTS"
+            else
+              echo "⚠️ Failed to generate owed.txt from $RECEIPTS" >&2
+              echo "⚠️ Failed to generate owed table from $RECEIPTS." > owed.txt
+              echo "" >> owed.txt
+              echo "TOTAL OWED: 0" >> owed.txt
+            fi
+          else
+            echo "⚠️ No receipts.json found; creating placeholder owed.txt" >&2
+            echo "⚠️ No receipts manifest found for owed table generation." > owed.txt
+            echo "" >> owed.txt
+            echo "TOTAL OWED: 0" >> owed.txt
+          fi
       - name: 💬 Comment results on PR
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## Summary
- add a workflow step that generates or backfills owed.txt prior to posting the PR comment
- attempt to run x402.sh when receipts are present and fall back to a placeholder owed.txt when they are missing

## Testing
- `cat <<'EOF' | bash ...` (generate owed.txt via new step logic)
- `node -e "const fs=require('fs'); const owed=fs.readFileSync('owed.txt','utf8'); console.log('Comment preview:\n'+owed.trim());"`


------
https://chatgpt.com/codex/tasks/task_e_68cff4051200832289cfe7b73e2f16e5