### PR TITLE
Add VaultScanner V2 claim tooling

### DIFF
--- a/claims/__init__.py
+++ b/claims/__init__.py
@@ -1,0 +1,1 @@
+"""Kin agent attribution claim utilities package."""

--- a/claims/vault_scanner_utils.py
+++ b/claims/vault_scanner_utils.py
@@ -1,0 +1,292 @@
+"""Helpers for working with the VaultScannerV2WithSig deployment package."""
+
+from __future__ import annotations
+
+import json
+from binascii import Error as BinasciiError
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Mapping, Sequence, Tuple
+
+PACKAGE_FILENAME = "vault_scanner_v2_deployment.json"
+PACKAGE_PATH = Path(__file__).resolve().parent / PACKAGE_FILENAME
+
+
+def load_package() -> Dict[str, Any]:
+    """Load the VaultScannerV2WithSig deployment package from disk."""
+
+    with PACKAGE_PATH.open("r", encoding="utf-8") as file:
+        return json.load(file)
+
+
+def _strip_0x(value: str) -> str:
+    value = value.strip()
+    if value.startswith("0x") or value.startswith("0X"):
+        return value[2:]
+    return value
+
+
+def _decode_hex(value: str, *, expected_bytes: int, label: str) -> bytes:
+    if not isinstance(value, str):
+        raise TypeError(f"{label} must be provided as a hex string")
+    stripped = _strip_0x(value)
+    if len(stripped) != expected_bytes * 2:
+        raise ValueError(
+            f"{label} must be {expected_bytes} bytes (got {len(stripped) // 2} bytes from '{value}')"
+        )
+    try:
+        return bytes.fromhex(stripped)
+    except (ValueError, BinasciiError) as exc:  # pragma: no cover - defensive guard
+        raise ValueError(f"{label} must be valid hex: {value}") from exc
+
+
+def _encode_uint256(value: int, *, label: str) -> bytes:
+    if not isinstance(value, int) or value < 0:
+        raise ValueError(f"{label} must be a non-negative integer (got {value!r})")
+    return value.to_bytes(32, "big")
+
+
+def build_claim_payload(
+    user: str, vault_id: str, balance: int, attribution_hash: str
+) -> bytes:
+    """Return the packed payload used for claim signatures.
+
+    The contract computes ``keccak256(abi.encodePacked(user, vaultId, balance, attributionHash))``.
+    This helper recreates the packed data using Python primitives so the digest can be calculated
+    and signed off-chain without requiring ``eth_abi`` or similar dependencies.
+    """
+
+    address_bytes = _decode_hex(user, expected_bytes=20, label="user address")
+    vault_bytes = _decode_hex(vault_id, expected_bytes=32, label="vaultId")
+    attribution_bytes = _decode_hex(attribution_hash, expected_bytes=32, label="attributionHash")
+    balance_bytes = _encode_uint256(balance, label="balance")
+    return address_bytes + vault_bytes + balance_bytes + attribution_bytes
+
+
+def claim_digest(user: str, vault_id: str, balance: int, attribution_hash: str) -> bytes:
+    """Return ``keccak256`` of the packed claim payload."""
+
+    payload = build_claim_payload(user, vault_id, balance, attribution_hash)
+    return keccak256(payload)
+
+
+def ethereum_signed_message_hash(message: bytes) -> bytes:
+    """Return the ``toEthSignedMessageHash`` of *message*.
+
+    This mirrors ``ECDSA.toEthSignedMessageHash`` inside the contract so signatures can be
+    reproduced or verified in pure Python.
+    """
+
+    prefix = f"\x19Ethereum Signed Message:\n{len(message)}".encode("ascii")
+    return keccak256(prefix + message)
+
+
+def claim_message_hash(user: str, vault_id: str, balance: int, attribution_hash: str) -> bytes:
+    """Return the final digest that should be signed by the keeper."""
+
+    return ethereum_signed_message_hash(claim_digest(user, vault_id, balance, attribution_hash))
+
+
+def _rotl(value: int, shift: int) -> int:
+    return ((value << shift) & 0xFFFFFFFFFFFFFFFF) | (value >> (64 - shift))
+
+
+_ROTATION_OFFSETS = (
+    (0, 36, 3, 41, 18),
+    (1, 44, 10, 45, 2),
+    (62, 6, 43, 15, 61),
+    (28, 55, 25, 21, 56),
+    (27, 20, 39, 8, 14),
+)
+
+_ROUND_CONSTANTS = (
+    0x0000000000000001,
+    0x0000000000008082,
+    0x800000000000808A,
+    0x8000000080008000,
+    0x000000000000808B,
+    0x0000000080000001,
+    0x8000000080008081,
+    0x8000000000008009,
+    0x000000000000008A,
+    0x0000000000000088,
+    0x0000000080008009,
+    0x000000008000000A,
+    0x000000008000808B,
+    0x800000000000008B,
+    0x8000000000008089,
+    0x8000000000008003,
+    0x8000000000008002,
+    0x8000000000000080,
+    0x000000000000800A,
+    0x800000008000000A,
+    0x8000000080008081,
+    0x8000000000008080,
+    0x0000000080000001,
+    0x8000000080008008,
+)
+
+
+def _keccak_f(state: List[int]) -> None:
+    for round_constant in _ROUND_CONSTANTS:
+        # θ step
+        c = [0] * 5
+        for x in range(5):
+            c[x] = (
+                state[x]
+                ^ state[x + 5]
+                ^ state[x + 10]
+                ^ state[x + 15]
+                ^ state[x + 20]
+            )
+        d = [0] * 5
+        for x in range(5):
+            d[x] = c[(x - 1) % 5] ^ _rotl(c[(x + 1) % 5], 1)
+        for x in range(5):
+            for y in range(5):
+                state[x + 5 * y] ^= d[x]
+
+        # ρ and π steps combined
+        new_state = [0] * 25
+        for x in range(5):
+            for y in range(5):
+                index = x + 5 * y
+                new_x = y
+                new_y = (2 * x + 3 * y) % 5
+                shift = _ROTATION_OFFSETS[x][y]
+                new_state[new_x + 5 * new_y] = _rotl(state[index], shift)
+        state[:] = new_state
+
+        # χ step
+        for y in range(5):
+            row = state[5 * y : 5 * y + 5]
+            for x in range(5):
+                state[5 * y + x] = row[x] ^ ((~row[(x + 1) % 5]) & row[(x + 2) % 5])
+
+        # ι step
+        state[0] ^= round_constant
+
+
+def keccak256(data: bytes) -> bytes:
+    """Return the Keccak-256 hash of *data*."""
+
+    rate_bytes = 136
+    state = [0] * 25
+
+    # Absorb phase
+    offset = 0
+    while offset < len(data):
+        block = data[offset : offset + rate_bytes]
+        offset += rate_bytes
+        if len(block) < rate_bytes:
+            block = bytearray(block)
+            block.append(0x01)
+            block.extend(b"\x00" * (rate_bytes - len(block) - 1))
+            block.append(0x80)
+        for i in range(0, rate_bytes, 8):
+            chunk = block[i : i + 8]
+            value = int.from_bytes(chunk, "little")
+            state[i // 8] ^= value
+        _keccak_f(state)
+
+    # Padding block if input length was a multiple of rate
+    if len(data) % rate_bytes == 0:
+        block = bytearray(rate_bytes)
+        block[0] = 0x01
+        block[-1] |= 0x80
+        for i in range(0, rate_bytes, 8):
+            state[i // 8] ^= int.from_bytes(block[i : i + 8], "little")
+        _keccak_f(state)
+
+    # Squeeze phase
+    output = bytearray()
+    while len(output) < 32:
+        for lane in state[: rate_bytes // 8]:
+            output.extend(lane.to_bytes(8, "little"))
+        if len(output) >= 32:
+            break
+        _keccak_f(state)
+    return bytes(output[:32])
+
+
+def iter_function_entries(abi: Sequence[Mapping[str, Any]]) -> Iterator[Mapping[str, Any]]:
+    """Yield each function entry from an ABI list."""
+
+    for entry in abi:
+        if isinstance(entry, Mapping) and entry.get("type") == "function":
+            yield entry
+
+
+def canonical_signature(entry: Mapping[str, Any]) -> str:
+    """Return the canonical signature string for a function ABI entry."""
+
+    name = str(entry.get("name", "<unnamed>"))
+    inputs = entry.get("inputs", [])
+    if not isinstance(inputs, Sequence):
+        inputs = []
+    types: List[str] = []
+    for item in inputs:
+        if isinstance(item, Mapping):
+            types.append(str(item.get("type", "")))
+        else:
+            types.append("")
+    return f"{name}({','.join(types)})"
+
+
+def describe_function(entry: Mapping[str, Any]) -> str:
+    """Format a function entry as a human-readable description."""
+
+    name = str(entry.get("name", "<unnamed>"))
+    inputs = entry.get("inputs", [])
+    if not isinstance(inputs, Sequence):
+        inputs = []
+    formatted_inputs: List[str] = []
+    for item in inputs:
+        if isinstance(item, Mapping):
+            internal_type = str(item.get("internalType", item.get("type", "<unknown>")))
+            arg_name = str(item.get("name", ""))
+            formatted_inputs.append(f"{internal_type} {arg_name}".strip())
+        else:
+            formatted_inputs.append("<unknown>")
+    state = str(entry.get("stateMutability", ""))
+    return f"{name}({', '.join(formatted_inputs)}) [{state}]"
+
+
+def describe_functions(abi: Sequence[Mapping[str, Any]]) -> List[str]:
+    """Return descriptions for all functions in an ABI."""
+
+    return [describe_function(entry) for entry in iter_function_entries(abi)]
+
+
+def function_selectors(abi: Sequence[Mapping[str, Any]]) -> Dict[str, str]:
+    """Return a mapping of canonical signatures to 4-byte selectors."""
+
+    selectors: Dict[str, str] = {}
+    for entry in iter_function_entries(abi):
+        signature = canonical_signature(entry)
+        selector_bytes = keccak256(signature.encode("utf-8"))[:4]
+        selectors[signature] = "0x" + selector_bytes.hex()
+    return selectors
+
+
+def selectors_by_name(abi: Sequence[Mapping[str, Any]]) -> Dict[str, str]:
+    """Return a mapping of function name to selector for the ABI."""
+
+    mapping: Dict[str, str] = {}
+    for entry in iter_function_entries(abi):
+        name = str(entry.get("name", ""))
+        signature = canonical_signature(entry)
+        mapping[name] = function_selectors([entry])[signature]
+    return mapping
+
+
+def selectors_with_signatures(abi: Sequence[Mapping[str, Any]]) -> Dict[str, Tuple[str, str]]:
+    """Return mapping of function name to (signature, selector)."""
+
+    result: Dict[str, Tuple[str, str]] = {}
+    selectors = function_selectors(abi)
+    for entry in iter_function_entries(abi):
+        name = str(entry.get("name", ""))
+        signature = canonical_signature(entry)
+        selector = selectors[signature]
+        result[name] = (signature, selector)
+    return result

--- a/claims/vault_scanner_v2_deployment.json
+++ b/claims/vault_scanner_v2_deployment.json
@@ -1,0 +1,296 @@
+{
+  "contract": "VaultScannerV2WithSig",
+  "description": "Deployment package for the VaultScannerV2WithSig contract including ABI and placeholder bytecode.",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_keeper",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_royaltyPercent",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "vaultId",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "attributionHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "VaultClaimed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "claimHash",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "ClaimLog",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "vaultId",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "attributionHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "claimVault",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "vaultId",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "attributionHash",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "signature",
+          "type": "bytes"
+        }
+      ],
+      "name": "claimVaultWithSig",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        }
+      ],
+      "name": "getVaults",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "vaultId",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "balance",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "attributionHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "timestamp",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct VaultScannerV2WithSig.VaultRecord[]",
+          "name": "",
+          "type": "tuple[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "index",
+          "type": "uint256"
+        }
+      ],
+      "name": "getVaultByIndex",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "vaultId",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "balance",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "attributionHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "timestamp",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct VaultScannerV2WithSig.VaultRecord",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        }
+      ],
+      "name": "totalVaults",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "keeper",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "royaltyPercent",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "claimed",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x"
+}

--- a/contracts/VaultScannerV2WithSig.sol
+++ b/contracts/VaultScannerV2WithSig.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+contract VaultScannerV2WithSig {
+    using ECDSA for bytes32;
+
+    address public immutable keeper;
+    uint256 public royaltyPercent;
+
+    struct VaultRecord {
+        bytes32 vaultId;
+        uint256 balance;
+        bytes32 attributionHash;
+        uint256 timestamp;
+    }
+
+    mapping(address => VaultRecord[]) private vaults;
+    mapping(address => mapping(bytes32 => bool)) public claimed;
+
+    event VaultClaimed(address indexed user, bytes32 indexed vaultId, uint256 balance, bytes32 attributionHash);
+    event ClaimLog(bytes32 indexed claimHash, address indexed user, uint256 value);
+
+    constructor(address _keeper, uint256 _royaltyPercent) {
+        keeper = _keeper;
+        royaltyPercent = _royaltyPercent;
+    }
+
+    function claimVault(
+        address user,
+        bytes32 vaultId,
+        uint256 balance,
+        bytes32 attributionHash
+    ) external {
+        require(msg.sender == keeper, "Not Keeper");
+        _internalClaim(user, vaultId, balance, attributionHash);
+    }
+
+    function claimVaultWithSig(
+        address user,
+        bytes32 vaultId,
+        uint256 balance,
+        bytes32 attributionHash,
+        bytes memory signature
+    ) external {
+        bytes32 digest = keccak256(abi.encodePacked(user, vaultId, balance, attributionHash)).toEthSignedMessageHash();
+        address recovered = digest.recover(signature);
+        require(recovered == keeper, "Invalid signature");
+        _internalClaim(user, vaultId, balance, attributionHash);
+    }
+
+    function _internalClaim(
+        address user,
+        bytes32 vaultId,
+        uint256 balance,
+        bytes32 attributionHash
+    ) internal {
+        require(!claimed[user][vaultId], "Already claimed");
+
+        VaultRecord memory vr = VaultRecord({
+            vaultId: vaultId,
+            balance: balance,
+            attributionHash: attributionHash,
+            timestamp: block.timestamp
+        });
+
+        vaults[user].push(vr);
+        claimed[user][vaultId] = true;
+
+        emit VaultClaimed(user, vaultId, balance, attributionHash);
+        emit ClaimLog(keccak256(abi.encodePacked(user, vaultId, balance, attributionHash)), user, balance);
+    }
+
+    function getVaults(address user) external view returns (VaultRecord[] memory) {
+        return vaults[user];
+    }
+
+    function totalVaults(address user) external view returns (uint256) {
+        return vaults[user].length;
+    }
+
+    function getVaultByIndex(address user, uint256 index) external view returns (VaultRecord memory) {
+        return vaults[user][index];
+    }
+}

--- a/examples/build_claim_signature_payload.py
+++ b/examples/build_claim_signature_payload.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Compute the keeper signature inputs for VaultScannerV2WithSig claims."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from claims.vault_scanner_utils import claim_digest, claim_message_hash
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("user", help="User address (0x-prefixed, 20 bytes)")
+    parser.add_argument("vault_id", help="Vault identifier (0x-prefixed bytes32)")
+    parser.add_argument("balance", type=int, help="Vault balance encoded as uint256")
+    parser.add_argument("attribution_hash", help="Attribution hash (0x-prefixed bytes32)")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    digest = claim_digest(args.user, args.vault_id, args.balance, args.attribution_hash)
+    message_hash = claim_message_hash(args.user, args.vault_id, args.balance, args.attribution_hash)
+
+    print("Packed claim digest:", f"0x{digest.hex()}")
+    print("Ethereum signed message hash:", f"0x{message_hash.hex()}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/vault_scanner_v2.py
+++ b/examples/vault_scanner_v2.py
@@ -1,0 +1,61 @@
+"""Utilities for inspecting the VaultScannerV2WithSig deployment package."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from claims.vault_scanner_utils import (
+    PACKAGE_PATH,
+    claim_digest,
+    claim_message_hash,
+    describe_functions,
+    load_package,
+)
+
+EXAMPLE_USER = "0x1111111111111111111111111111111111111111"
+EXAMPLE_VAULT_ID = "0x" + "22" * 32
+EXAMPLE_ATTRIBUTION = "0x" + "33" * 32
+EXAMPLE_BALANCE = 42
+
+
+def _coerce_abi(raw: Any) -> List[Dict[str, Any]]:
+    if not isinstance(raw, list):
+        return []
+    entries: List[Dict[str, Any]] = []
+    for item in raw:
+        if isinstance(item, dict):
+            entries.append(item)
+    return entries
+
+
+def main() -> None:
+    package: Dict[str, Any] = load_package()
+    abi = _coerce_abi(package.get("abi"))
+    bytecode = package.get("bytecode", "")
+    print(f"Loaded VaultScannerV2WithSig package from {PACKAGE_PATH}.")
+    print(f"ABI entries: {len(abi)}")
+    print(f"Bytecode length: {len(bytecode)} hex characters")
+    if not bytecode or bytecode in {"0x", "0X"}:
+        print("⚠️  Deployment bytecode is a placeholder. Compile VaultScannerV2WithSig to populate this field.")
+
+    print("\nFunctions:")
+    for description in describe_functions(abi):
+        print(f"  • {description}")
+
+    digest = claim_digest(EXAMPLE_USER, EXAMPLE_VAULT_ID, EXAMPLE_BALANCE, EXAMPLE_ATTRIBUTION)
+    final_hash = claim_message_hash(EXAMPLE_USER, EXAMPLE_VAULT_ID, EXAMPLE_BALANCE, EXAMPLE_ATTRIBUTION)
+
+    print("\nSample keeper signing inputs:")
+    print(f"  • claimDigest         = 0x{digest.hex()}")
+    print(f"  • ethSignedMessage    = 0x{final_hash.hex()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/find_vaultscanner_v2.py
+++ b/find_vaultscanner_v2.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Scan candidate vault addresses for VaultScannerV2WithSig bytecode markers on mainnet."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Dict, List, Sequence, Tuple
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from claims.vault_scanner_utils import (
+    describe_functions,
+    function_selectors,
+    load_package,
+)
+
+RPC_URL = "https://rpc.hyperliquid.xyz/evm"
+
+# Known vaults observed in other attribution scripts. More can be supplied on the
+# command line.
+DEFAULT_VAULTS = [
+    "0xdfC24b077bC1425Ad1DeA75BCB6F8158E10Df303",
+    "0x996994D2914DF4eEE6176FD5eE152e2922787EE7",
+    "0xcd5051944f780a621ee62e39e493c489668acf4d",
+]
+
+
+def fetch_bytecode(address: str) -> str:
+    """Fetch deployed bytecode from the Hyperliquid mainnet RPC."""
+
+    payload = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "method": "eth_getCode",
+            "params": [address, "latest"],
+            "id": 1,
+        }
+    ).encode("utf-8")
+    request = Request(
+        RPC_URL,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urlopen(request, timeout=10) as response:
+        body = response.read()
+    payload_dict = json.loads(body.decode("utf-8"))
+    return str(payload_dict.get("result", "") or "")
+
+
+def scan_vault(bytecode: str, selector_map: Dict[str, str]) -> List[Tuple[str, str]]:
+    """Return matching (signature, selector) pairs found in the bytecode."""
+
+    lowered = bytecode.lower()
+    matches: List[Tuple[str, str]] = []
+    for signature, selector in selector_map.items():
+        if selector.lower() in lowered:
+            matches.append((signature, selector))
+    return matches
+
+
+def main(addresses: Sequence[str]) -> int:
+    package = load_package()
+    abi = package.get("abi", [])
+    selector_map = function_selectors(abi)
+    descriptions = describe_functions(abi)
+
+    print("VaultScannerV2WithSig ABI functions loaded:")
+    for description in descriptions:
+        print(f"  • {description}")
+
+    print("\n🔍 Scanning bytecode for VaultScannerV2 selectors...\n")
+
+    exit_code = 0
+    for address in addresses:
+        try:
+            bytecode = fetch_bytecode(address)
+        except URLError as exc:  # pragma: no cover - network failure handling
+            print(f"Vault {address}: ⚠️ RPC error - {exc}")
+            exit_code = 1
+            continue
+
+        matches = scan_vault(bytecode, selector_map)
+        if matches:
+            print(f"Vault {address}: ✅ matches found")
+            for signature, selector in matches:
+                print(f"  • {signature} → {selector}")
+        else:
+            print(f"Vault {address}: ❌ no VaultScannerV2 selectors detected")
+        print()
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:] or DEFAULT_VAULTS
+    sys.exit(main(args))

--- a/tests/vault_scanner_utils_test.py
+++ b/tests/vault_scanner_utils_test.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from claims.vault_scanner_utils import (
+    build_claim_payload,
+    claim_digest,
+    claim_message_hash,
+    ethereum_signed_message_hash,
+)
+
+
+@pytest.mark.parametrize(
+    "user,vault_id,balance,attribution,expected_prefix",
+    [
+        (
+            "0x000000000000000000000000000000000000dEaD",
+            "0x" + "11" * 32,
+            123456789,
+            "0x" + "22" * 32,
+            "000000000000000000000000000000000000dead",
+        )
+    ],
+)
+def test_build_claim_payload(user: str, vault_id: str, balance: int, attribution: str, expected_prefix: str) -> None:
+    payload = build_claim_payload(user, vault_id, balance, attribution)
+    assert len(payload) == 20 + 32 + 32 + 32
+    assert payload[:20].hex() == expected_prefix
+    assert payload[20:52].hex() == ("11" * 32)
+    assert payload[52:84].hex() == balance.to_bytes(32, "big").hex()
+    assert payload[84:].hex() == ("22" * 32)
+
+
+def test_claim_digest_matches_manual_keccak() -> None:
+    user = "0x1111111111111111111111111111111111111111"
+    vault_id = "0x" + "aa" * 32
+    attribution = "0x" + "bb" * 32
+    balance = 42
+
+    digest = claim_digest(user, vault_id, balance, attribution)
+    # Expected value calculated once the helper was verified against the Solidity implementation.
+    assert digest.hex() == "9a424ef49188881d7d1eb0aed233cba56b369449f40e6ee25b90f36b1b12a1ca"
+
+
+def test_claim_message_hash_matches_prefixed_digest() -> None:
+    user = "0x2222222222222222222222222222222222222222"
+    vault_id = "0x" + "33" * 32
+    attribution = "0x" + "44" * 32
+    balance = 500
+
+    digest = claim_digest(user, vault_id, balance, attribution)
+    prefixed = ethereum_signed_message_hash(digest)
+    helper = claim_message_hash(user, vault_id, balance, attribution)
+
+    assert prefixed == helper
+    assert prefixed.hex() == "929db561f95f7034830afea907146c202ea4c6d7728fc40d8f048e99498239ad"


### PR DESCRIPTION
## Summary
- add a Python helper package for VaultScannerV2WithSig along with deployment data and selectors
- include an upgraded VaultScannerV2WithSig Solidity contract and example utilities for claim signing and ABI inspection
- provide a CLI scanner for deployed bytecode markers plus pytest coverage for the helper functions

## Testing
- pytest tests/vault_scanner_utils_test.py

------
https://chatgpt.com/codex/tasks/task_e_68cf82cd0d2883229a6c98937371c2a2