### PR TITLE
Add golangci-lint GitHub Action workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,29 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+      - seiv2
+  pull_request:
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.21
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.60.1
+          args: --timeout 10m0s


### PR DESCRIPTION
## Summary
- add a golangci-lint workflow that runs on pushes to main branches, tags, and PRs
- configure the action to use Go 1.21 and golangci-lint v1.60.1

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d0b0f375448322b44612af2d595dfd