### PR TITLE
Add msg_claim deployment helper

### DIFF
--- a/deploy/msg_claim.mjs
+++ b/deploy/msg_claim.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from "fs";
+import process from "process";
+import { ethers } from "ethers";
+
+const SOLO_PRECOMPILE_ADDRESS = "0x000000000000000000000000000000000000100C";
+const SOLO_ABI = [
+  {
+    inputs: [{ internalType: "bytes", name: "payload", type: "bytes" }],
+    name: "claim",
+    outputs: [{ internalType: "bool", name: "response", type: "bool" }],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "bytes", name: "payload", type: "bytes" }],
+    name: "claimSpecific",
+    outputs: [{ internalType: "bool", name: "response", type: "bool" }],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+];
+
+const FLAG_WITH_VALUE = new Set([
+  "payload",
+  "rpc-url",
+  "gas-limit",
+  "gas-price",
+  "max-fee-per-gas",
+  "max-priority-fee-per-gas",
+  "nonce",
+  "chain-id",
+]);
+
+const BOOLEAN_FLAGS = new Set(["claim-specific", "dry-run", "no-wait"]);
+
+function printHelp(exitCode = 0) {
+  console.log(`Usage: node deploy/msg_claim.mjs --payload <hex|file> [options]\n\n` +
+    `Required:\n` +
+    `  --payload <value>          Hex string or path to file with Cosmos-signed payload.\n\n` +
+    `When broadcasting (default behaviour):\n` +
+    `  --rpc-url <url>            HTTP RPC endpoint for Sei EVM.\n` +
+    `  PRIVATE_KEY env var        Private key used to sign the transaction.\n\n` +
+    `Optional flags:\n` +
+    `  --claim-specific           Call claimSpecific(bytes) instead of claim(bytes).\n` +
+    `  --gas-limit <value>        Gas limit to use (default 750000).\n` +
+    `  --gas-price <gwei>         Legacy gas price in gwei.\n` +
+    `  --max-fee-per-gas <gwei>   EIP-1559 maxFeePerGas in gwei (requires --max-priority-fee-per-gas).\n` +
+    `  --max-priority-fee-per-gas <gwei>  EIP-1559 tip in gwei.\n` +
+    `  --nonce <value>            Override the nonce instead of querying RPC.\n` +
+    `  --chain-id <value>         Chain ID hint when connecting to RPC.\n` +
+    `  --dry-run                  Do not broadcast; print transaction skeleton instead.\n` +
+    `  --no-wait                  Do not wait for transaction confirmation.\n` +
+    `  -h, --help                 Show this message.\n`);
+  process.exit(exitCode);
+}
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+      continue;
+    }
+    if (!arg.startsWith("--")) {
+      throw new Error(`Unexpected positional argument '${arg}'.`);
+    }
+    const flag = arg.slice(2);
+    if (BOOLEAN_FLAGS.has(flag)) {
+      parsed[flag] = true;
+      continue;
+    }
+    if (!FLAG_WITH_VALUE.has(flag)) {
+      throw new Error(`Unknown flag --${flag}. Use --help to list supported options.`);
+    }
+    if (i + 1 >= argv.length) {
+      throw new Error(`Flag --${flag} requires a value.`);
+    }
+    parsed[flag] = argv[i + 1];
+    i += 1;
+  }
+  return parsed;
+}
+
+function ensure0x(hex) {
+  return hex.startsWith("0x") ? hex : `0x${hex}`;
+}
+
+function normalizeHex(hex) {
+  const prefixed = ensure0x(hex.trim());
+  if (!/^0x[0-9a-fA-F]*$/.test(prefixed)) {
+    throw new Error("Payload must be a hex string when provided inline.");
+  }
+  if (prefixed.length % 2 !== 0) {
+    throw new Error("Payload hex must have an even number of characters.");
+  }
+  return prefixed;
+}
+
+function loadPayload(input) {
+  if (existsSync(input)) {
+    const raw = readFileSync(input);
+    const asString = raw.toString().trim();
+    if (asString.length > 0 && /^0x?[0-9a-fA-F]+$/.test(asString)) {
+      return normalizeHex(asString);
+    }
+    return ensure0x(Buffer.from(raw).toString("hex"));
+  }
+  return normalizeHex(input);
+}
+
+function parseIntegerOption(value, flagName) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`--${flagName} must be a non-negative integer.`);
+  }
+  return parsed;
+}
+
+function buildGasOverrides(options) {
+  const overrides = {};
+  const gasLimitSource = options["gas-limit"] ?? process.env.CLAIM_TX_GAS_LIMIT;
+  if (gasLimitSource !== undefined) {
+    overrides.gasLimit = BigInt(parseIntegerOption(gasLimitSource, "gas-limit"));
+  } else {
+    overrides.gasLimit = 750000n;
+  }
+
+  if (options["gas-price"] !== undefined) {
+    overrides.gasPrice = ethers.parseUnits(options["gas-price"], "gwei");
+  }
+
+  const hasMaxFee = options["max-fee-per-gas"] !== undefined;
+  const hasPriority = options["max-priority-fee-per-gas"] !== undefined;
+  if (hasMaxFee || hasPriority) {
+    if (!(hasMaxFee && hasPriority)) {
+      throw new Error("Both --max-fee-per-gas and --max-priority-fee-per-gas must be set together.");
+    }
+    overrides.maxFeePerGas = ethers.parseUnits(options["max-fee-per-gas"], "gwei");
+    overrides.maxPriorityFeePerGas = ethers.parseUnits(
+      options["max-priority-fee-per-gas"],
+      "gwei",
+    );
+    delete overrides.gasPrice;
+  }
+
+  if (options.nonce !== undefined) {
+    overrides.nonce = parseIntegerOption(options.nonce, "nonce");
+  }
+
+  return overrides;
+}
+
+async function maybePopulateFees(overrides, provider) {
+  if (("gasPrice" in overrides) || ("maxFeePerGas" in overrides) || !provider) {
+    return overrides;
+  }
+
+  const feeData = await provider.getFeeData();
+  if (feeData.maxFeePerGas != null && feeData.maxPriorityFeePerGas != null) {
+    overrides.maxFeePerGas = feeData.maxFeePerGas;
+    overrides.maxPriorityFeePerGas = feeData.maxPriorityFeePerGas;
+  } else if (feeData.gasPrice != null) {
+    overrides.gasPrice = feeData.gasPrice;
+  } else {
+    throw new Error(
+      "RPC did not return usable fee data. Provide --gas-price or EIP-1559 flags explicitly.",
+    );
+  }
+  return overrides;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp(0);
+  }
+  if (!args.payload) {
+    console.error("Missing required --payload argument.\n");
+    printHelp(1);
+  }
+
+  const payloadHex = loadPayload(args.payload);
+  const method = args["claim-specific"] ? "claimSpecific" : "claim";
+  const iface = new ethers.Interface(SOLO_ABI);
+  const calldata = iface.encodeFunctionData(method, [payloadHex]);
+
+  const overrides = buildGasOverrides(args);
+
+  if (args["dry-run"]) {
+    const summary = {
+      to: SOLO_PRECOMPILE_ADDRESS,
+      method,
+      gasLimit: overrides.gasLimit?.toString?.() ?? undefined,
+      feeFields: {
+        gasPrice: overrides.gasPrice ? overrides.gasPrice.toString() : undefined,
+        maxFeePerGas: overrides.maxFeePerGas ? overrides.maxFeePerGas.toString() : undefined,
+        maxPriorityFeePerGas: overrides.maxPriorityFeePerGas
+          ? overrides.maxPriorityFeePerGas.toString()
+          : undefined,
+      },
+      nonce: overrides.nonce,
+      data: calldata,
+    };
+    console.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
+  const rpcUrl =
+    args["rpc-url"] || process.env.SEI_EVM_RPC_URL || process.env.RPC_URL;
+  if (!rpcUrl) {
+    throw new Error("RPC URL is required when broadcasting. Provide --rpc-url or set SEI_EVM_RPC_URL.");
+  }
+
+  const chainId = args["chain-id"] !== undefined ? parseIntegerOption(args["chain-id"], "chain-id") : undefined;
+  const provider = new ethers.JsonRpcProvider(rpcUrl, chainId);
+  const privateKey = process.env.PRIVATE_KEY;
+  if (!privateKey) {
+    throw new Error("PRIVATE_KEY environment variable is required to sign the transaction.");
+  }
+
+  const wallet = new ethers.Wallet(privateKey, provider);
+  await maybePopulateFees(overrides, provider);
+
+  const txRequest = {
+    to: SOLO_PRECOMPILE_ADDRESS,
+    data: calldata,
+    value: 0n,
+    ...overrides,
+  };
+
+  console.log(`Submitting ${method} transaction from ${wallet.address}...`);
+  const response = await wallet.sendTransaction(txRequest);
+  console.log(`Transaction hash: ${response.hash}`);
+
+  if (args["no-wait"]) {
+    return;
+  }
+
+  const receipt = await response.wait();
+  if (!receipt) {
+    console.warn("Transaction submitted but no receipt was returned (provider may not support wait).");
+    return;
+  }
+  console.log(`Status: ${receipt.status === 1 ? "SUCCESS" : "FAILED"}`);
+  console.log(`Gas used: ${receipt.gasUsed?.toString() ?? "unknown"}`);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/docs/codespace_claim_tx.md
+++ b/docs/codespace_claim_tx.md
@@ -1,0 +1,132 @@
+# Building Sei Solo claim transactions in GitHub Codespaces
+
+The [`scripts/build_claim_tx.py`](../scripts/build_claim_tx.py) helper signs the EVM
+transaction locally and writes the raw hex blob to disk so you can broadcast it
+with `seid tx broadcast` or the `/txs` RPC endpoint. The workflow below walks
+through using the script inside a GitHub Codespace so the private key never
+leaves your isolated development environment.
+
+> **Never hard-code or commit private keys.** Store them as Codespace secrets or
+> export them only for the lifetime of your terminal session.
+
+## 1. Launch a Codespace
+
+1. Navigate to your fork of [`sei-chain`](https://github.com/sei-protocol/sei-chain).
+2. Click **Code** → **Codespaces** → **Create codespace on main** (or the branch
+   you prefer).
+3. Wait for the container to build and for the web-based VS Code terminal to
+   appear.
+
+## 2. Configure Python dependencies
+
+The default Codespace image already ships with Python 3. If you want to keep the
+helper’s dependencies isolated, create a virtual environment first:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install web3 eth-account
+```
+
+If you reuse the Codespace later, just run `source .venv/bin/activate` followed
+by `pip install --upgrade web3 eth-account` to pick up updates.
+
+## 3. Provide access to the signing key
+
+Prefer GitHub Codespaces secrets when possible:
+
+1. Open **Repository settings** → **Codespaces secrets**.
+2. Add a secret named `PRIVATE_KEY` whose value is the EVM private key.
+3. Rebuild or restart the Codespace so the secret is injected.
+
+Inside the terminal, expose the key just before running the helper:
+
+```bash
+export PRIVATE_KEY="$PRIVATE_KEY"
+```
+
+If you cannot use secrets, export the value manually in the terminal. Avoid
+copying it into files that could be committed.
+
+## 4. Load the Cosmos payload
+
+Save the signed Cosmos transaction blob (from your off-chain signer) into the
+Codespace workspace:
+
+```bash
+cat <<'PAYLOAD' > claim_payload.hex
+0x0123abcd...
+PAYLOAD
+```
+
+The helper accepts either a `0x`-prefixed hex string or a binary payload file.
+
+## 5. Configure optional RPC lookups
+
+Set the RPC endpoint if you want the helper to fetch the current nonce and gas
+price automatically:
+
+```bash
+export SEI_EVM_RPC_URL="https://evm-rpc.sei.example"
+```
+
+Skip this step and pass `--nonce` and fee flags explicitly if you prefer full
+manual control.
+
+## 6. Build the transaction
+
+Run the helper from the repository root:
+
+```bash
+python scripts/build_claim_tx.py \
+  --payload claim_payload.hex \
+  --gas-limit 750000 \
+  --chain-id 1329 \
+  --output signed_claim.json
+```
+
+Use `--claim-specific` when your payload wraps `MsgClaimSpecific`. To pin legacy
+fees and the nonce explicitly:
+
+```bash
+python scripts/build_claim_tx.py \
+  --payload claim_payload.hex \
+  --gas-limit 750000 \
+  --chain-id 1329 \
+  --gas-price 0.02 \
+  --nonce 7
+```
+
+Both commands print the raw transaction hex blob to stdout and write a JSON
+summary to `signed_claim.json`.
+
+## 7. Retrieve the signed transaction
+
+Right-click `signed_claim.json` in the VS Code Explorer and choose **Download**
+if you need the file locally. Alternatively, copy the `raw_transaction` field
+from the terminal output.
+
+## 8. Broadcast manually
+
+Broadcast the raw hex from a trusted environment using either pattern:
+
+```bash
+seid tx broadcast signed_claim.json
+# or
+curl -X POST "https://sei-rpc.example/txs" \
+  -H 'Content-Type: application/json' \
+  -d '{"tx_bytes": "<raw_hex>", "mode": "BROADCAST_MODE_SYNC"}'
+```
+
+Replace `sei-rpc.example` and the broadcast mode according to your
+infrastructure needs.
+
+## Troubleshooting tips
+
+- `ValueError: Payload hex must have an even number of characters` – double
+  check the payload file; each byte needs two hexadecimal characters.
+- `Nonce is required when no RPC endpoint is available` – pass `--nonce` or set
+  `SEI_EVM_RPC_URL`.
+- `ModuleNotFoundError: No module named 'eth_account'` – activate your virtual
+  environment and reinstall dependencies with `pip install web3 eth-account`.

--- a/docs/deploy_msg_claim.md
+++ b/docs/deploy_msg_claim.md
@@ -1,0 +1,91 @@
+# Deploying `MsgClaim` transactions from Node.js
+
+The [`deploy/msg_claim.mjs`](../deploy/msg_claim.mjs) helper sends the Sei Solo
+precompile call (`claim(bytes)` or `claimSpecific(bytes)`) directly to the
+network. It expects the Cosmos-signed payload that was produced off-chain by
+`seid tx sign --generate-only` or another signer, then wraps and broadcasts the
+EVM transaction for you.
+
+## Prerequisites
+
+- Node.js 18 or later
+- A Sei EVM account with funds for gas
+- The Cosmos-signed payload for either `MsgClaim` or `MsgClaimSpecific`
+- The private key for the EVM account you will broadcast from
+
+Install the JavaScript dependencies once per checkout:
+
+```bash
+npm install
+```
+
+## 1. Export the signing key securely
+
+Store the private key in an environment variable for the current shell session.
+Avoid pasting it into command history.
+
+```bash
+export PRIVATE_KEY="0xyour_private_key"
+```
+
+## 2. Provide the Cosmos payload
+
+Save the signed payload to disk. The helper accepts either a binary file or a
+hex string (with or without the `0x` prefix).
+
+```bash
+cat <<'PAYLOAD' > claim_payload.hex
+0x0123abcd...
+PAYLOAD
+```
+
+## 3. Dry-run to inspect the transaction (optional)
+
+Use the `--dry-run` flag to preview the call data and gas configuration without
+broadcasting:
+
+```bash
+node deploy/msg_claim.mjs \
+  --payload claim_payload.hex \
+  --claim-specific \
+  --gas-limit 750000 \
+  --dry-run
+```
+
+The command prints a JSON summary that includes the encoded calldata. Adjust
+fees or the `--claim-specific` toggle as needed.
+
+## 4. Broadcast the transaction
+
+When you are ready, provide an RPC endpoint and run the script without
+`--dry-run`:
+
+```bash
+node deploy/msg_claim.mjs \
+  --payload claim_payload.hex \
+  --rpc-url https://sei-evm-rpc.example \
+  --gas-price 0.02
+```
+
+The helper automatically queries fee data from the RPC when you do not supply
+`--gas-price` or the EIP-1559 flags. Set `--no-wait` if you do not want to wait
+for the transaction receipt.
+
+### Customising fees and nonce
+
+- `--gas-price <gwei>` – Sends a legacy-style transaction.
+- `--max-fee-per-gas` and `--max-priority-fee-per-gas` – Sends an EIP-1559
+  transaction. You must provide both flags together.
+- `--nonce <value>` – Overrides the account nonce if you need to replay or queue
+  a specific sequence.
+
+### Chain ID hints
+
+If the RPC endpoint serves multiple networks behind the same URL, pass
+`--chain-id` to enforce the expected chain ID during the connection handshake.
+
+### Broadcasting manually
+
+The script prints the transaction hash immediately. If you set `--no-wait` (or
+terminate the script early) you can still query status later with `seid tx hash
+<tx_hash>` or an RPC explorer.

--- a/docs/termux_claim_tx.md
+++ b/docs/termux_claim_tx.md
@@ -1,0 +1,121 @@
+# Building Sei Solo claim transactions in Termux
+
+The [`scripts/build_claim_tx.py`](../scripts/build_claim_tx.py) helper signs the EVM
+transaction locally and writes the raw hex blob to disk so you can broadcast it
+with `seid tx broadcast` or the `/txs` RPC endpoint. The steps below assume you
+already have:
+
+- a Sei EVM account with enough ETH to cover gas,
+- the Cosmos-signed payload produced off-chain for either `MsgClaim` or
+  `MsgClaimSpecific`, and
+- the corresponding private key you want to use for the EVM transaction.
+
+> **Never hard-code or commit private keys.** Always load them at runtime from
+> an environment variable or prompt.
+
+## 1. Prepare Termux
+
+```bash
+pkg update
+pkg install -y python git clang make openssl
+python -m ensurepip --upgrade
+pip install --upgrade pip virtualenv
+```
+
+## 2. Grab the helper and its dependencies
+
+```bash
+cd ~
+git clone https://github.com/sei-protocol/sei-chain.git
+cd sei-chain
+python -m venv .venv
+source .venv/bin/activate
+pip install web3 eth-account
+```
+
+If you already have a checkout, just pull the latest changes and upgrade the
+Python dependencies inside your virtual environment.
+
+## 3. Export the signing key
+
+Termux shells reset environment variables between sessions, so export the key
+immediately before running the script:
+
+```bash
+export PRIVATE_KEY="0xyour_private_key_without_quotes"
+```
+
+For better hygiene, consider using `read -s` to prompt for the value each time
+instead of storing it in shell history.
+
+## 4. Provide the Cosmos payload
+
+Save the signed Cosmos transaction blob (from your off-chain signer) to a file.
+For example:
+
+```bash
+cat <<'PAYLOAD' > claim_payload.hex
+0x0123abcd...
+PAYLOAD
+```
+
+The helper accepts either a `0x`-prefixed hex string or a binary file.
+
+## 5. Query account metadata (optional)
+
+If you know the nonce and fees you want to use, you can skip this step. When
+connected to an RPC endpoint, the script will fetch both automatically:
+
+```bash
+export SEI_EVM_RPC_URL="https://evm-rpc.sei.example"
+```
+
+## 6. Build the transaction
+
+```bash
+python scripts/build_claim_tx.py \
+  --payload claim_payload.hex \
+  --gas-limit 750000 \
+  --chain-id 1329 \
+  --output signed_claim.json
+```
+
+Use `--claim-specific` when your payload wraps `MsgClaimSpecific`. To override
+fees explicitly:
+
+```bash
+python scripts/build_claim_tx.py \
+  --payload claim_payload.hex \
+  --gas-limit 750000 \
+  --chain-id 1329 \
+  --gas-price 0.02 \
+  --nonce 7
+```
+
+Both invocations print the raw transaction hex blob to stdout and save a JSON
+summary in `signed_claim.json`.
+
+## 7. Broadcast manually
+
+Copy the raw hex (`raw_transaction`) into a file, then broadcast from another
+machine or via Termux using either of the following patterns:
+
+```bash
+seid tx broadcast signed_claim.json
+# or
+curl -X POST "https://sei-rpc.example/txs" \
+  -H 'Content-Type: application/json' \
+  -d '{"tx_bytes": "<raw_hex>", "mode": "BROADCAST_MODE_SYNC"}'
+```
+
+Replace `sei-rpc.example` and the broadcast mode as required by your
+infrastructure.
+
+## Troubleshooting tips
+
+- `ValueError: Payload hex must have an even number of characters` – double
+  check the payload file; each byte needs two hexadecimal characters.
+- `Nonce is required when no RPC endpoint is available` – pass `--nonce` or set
+  `SEI_EVM_RPC_URL`.
+- `Unable to connect to RPC` – verify the endpoint URL and that Termux has
+  network connectivity.

--- a/scripts/build_claim_tx.py
+++ b/scripts/build_claim_tx.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Utility to build and sign Sei Solo precompile claim transactions offline."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from eth_account import Account  # type: ignore[import]
+from eth_account.signers.local import LocalAccount  # type: ignore[import]
+from web3 import Web3  # type: ignore[import]
+from web3.contract import ContractFunction  # type: ignore[import]
+
+SOLO_PRECOMPILE_ADDRESS = Web3.to_checksum_address(
+    "0x000000000000000000000000000000000000100C"
+)
+
+SOLO_ABI = json.loads(
+    """
+    [
+      {
+        "inputs": [
+          {"internalType": "bytes", "name": "payload", "type": "bytes"}
+        ],
+        "name": "claim",
+        "outputs": [
+          {"internalType": "bool", "name": "response", "type": "bool"}
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {"internalType": "bytes", "name": "payload", "type": "bytes"}
+        ],
+        "name": "claimSpecific",
+        "outputs": [
+          {"internalType": "bool", "name": "response", "type": "bool"}
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    ]
+    """
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build and sign an offline Sei Solo precompile transaction that calls "
+            "either claim(bytes) or claimSpecific(bytes)."
+        )
+    )
+    parser.add_argument(
+        "--payload",
+        required=True,
+        help=(
+            "Hex string (with or without 0x prefix) or path to a file containing the "
+            "Cosmos-signed MsgClaim or MsgClaimSpecific payload."
+        ),
+    )
+    parser.add_argument(
+        "--claim-specific",
+        action="store_true",
+        help="Encode the call to claimSpecific(bytes) instead of claim(bytes).",
+    )
+    parser.add_argument(
+        "--chain-id",
+        type=int,
+        default=int(os.getenv("SEI_EVM_CHAIN_ID", 1329)),
+        help="Sei EVM chain ID. Defaults to value from SEI_EVM_CHAIN_ID env var or 1329.",
+    )
+    parser.add_argument(
+        "--gas-limit",
+        type=int,
+        default=int(os.getenv("CLAIM_TX_GAS_LIMIT", 750000)),
+        help="Gas limit to use for the transaction. Defaults to 750000.",
+    )
+    parser.add_argument(
+        "--gas-price",
+        type=float,
+        default=None,
+        help=(
+            "Legacy gas price to use in gwei. Ignored if max-fee-per-gas is provided. "
+            "If omitted, the script uses the RPC gas price when --rpc-url is set."
+        ),
+    )
+    parser.add_argument(
+        "--max-fee-per-gas",
+        type=float,
+        default=None,
+        help="EIP-1559 maxFeePerGas in gwei. Requires --max-priority-fee-per-gas.",
+    )
+    parser.add_argument(
+        "--max-priority-fee-per-gas",
+        type=float,
+        default=None,
+        help="EIP-1559 maxPriorityFeePerGas in gwei.",
+    )
+    parser.add_argument(
+        "--nonce",
+        type=int,
+        default=None,
+        help=(
+            "Account nonce to use. If not provided, the script fetches it from the "
+            "RPC endpoint."
+        ),
+    )
+    parser.add_argument(
+        "--rpc-url",
+        type=str,
+        default=os.getenv("SEI_EVM_RPC_URL"),
+        help="HTTP RPC endpoint used to query nonce and (optionally) gas price.",
+    )
+    parser.add_argument(
+        "--output",
+        default=os.getenv("SIGNED_TX_OUTPUT", "signed_claim.json"),
+        help="File path where the signed transaction JSON should be written.",
+    )
+    parser.add_argument(
+        "--no-stdout",
+        action="store_true",
+        help="Do not echo the signed transaction hex blob to stdout.",
+    )
+    return parser.parse_args()
+
+
+def load_payload(arg: str) -> bytes:
+    potential_path = Path(arg)
+    if potential_path.exists():
+        data = potential_path.read_bytes()
+        if data.startswith(b"0x"):
+            data = data.strip()
+            return bytes.fromhex(data.decode()[2:])
+        return data
+    text = arg.strip().lower()
+    if text.startswith("0x"):
+        text = text[2:]
+    if len(text) % 2:
+        raise ValueError("Payload hex must have an even number of characters.")
+    return bytes.fromhex(text)
+
+
+def build_contract_call(payload: bytes, claim_specific: bool) -> ContractFunction:
+    web3 = Web3()
+    contract = web3.eth.contract(address=SOLO_PRECOMPILE_ADDRESS, abi=SOLO_ABI)
+    if claim_specific:
+        return contract.functions.claimSpecific(payload)
+    return contract.functions.claim(payload)
+
+
+def initialise_account() -> LocalAccount:
+    private_key = os.getenv("PRIVATE_KEY")
+    if not private_key:
+        raise SystemExit(
+            "PRIVATE_KEY environment variable is required to sign the transaction."
+        )
+    return Account.from_key(private_key)
+
+
+def ensure_fee_fields(
+    args: argparse.Namespace, rpc_web3: Optional[Web3]
+) -> dict[str, int]:
+    fee_fields: dict[str, int] = {}
+    if args.max_fee_per_gas is not None or args.max_priority_fee_per_gas is not None:
+        if args.max_fee_per_gas is None or args.max_priority_fee_per_gas is None:
+            raise SystemExit(
+                "Both --max-fee-per-gas and --max-priority-fee-per-gas must be provided for EIP-1559 transactions."
+            )
+        fee_fields["maxFeePerGas"] = Web3.to_wei(args.max_fee_per_gas, "gwei")
+        fee_fields["maxPriorityFeePerGas"] = Web3.to_wei(
+            args.max_priority_fee_per_gas, "gwei"
+        )
+        return fee_fields
+
+    if args.gas_price is not None:
+        fee_fields["gasPrice"] = Web3.to_wei(args.gas_price, "gwei")
+        return fee_fields
+
+    if rpc_web3 is None:
+        raise SystemExit(
+            "Provide --gas-price, EIP-1559 fee flags, or an --rpc-url to pull gas price automatically."
+        )
+    fee_fields["gasPrice"] = rpc_web3.eth.gas_price
+    return fee_fields
+
+
+def fetch_nonce(account: LocalAccount, args: argparse.Namespace, rpc_web3: Optional[Web3]) -> int:
+    if args.nonce is not None:
+        return args.nonce
+    if rpc_web3 is None:
+        raise SystemExit(
+            "Nonce is required when no RPC endpoint is available. Pass --nonce or --rpc-url."
+        )
+    return rpc_web3.eth.get_transaction_count(account.address)
+
+
+def connect_web3(args: argparse.Namespace) -> Optional[Web3]:
+    if not args.rpc_url:
+        return None
+    provider = Web3.HTTPProvider(args.rpc_url)
+    web3 = Web3(provider)
+    if not web3.is_connected():
+        raise SystemExit(f"Unable to connect to RPC at {args.rpc_url!r}.")
+    return web3
+
+
+def main() -> int:
+    args = parse_args()
+    account = initialise_account()
+    payload = load_payload(args.payload)
+    contract_function = build_contract_call(payload, args.claim_specific)
+
+    rpc_web3 = connect_web3(args)
+    nonce = fetch_nonce(account, args, rpc_web3)
+    fee_fields = ensure_fee_fields(args, rpc_web3)
+
+    tx: dict[str, int | str | bytes] = {
+        "chainId": args.chain_id,
+        "nonce": nonce,
+        "gas": args.gas_limit,
+        "to": SOLO_PRECOMPILE_ADDRESS,
+        "data": contract_function.build_transaction({})["data"],
+        "value": 0,
+    }
+    tx.update(fee_fields)
+
+    signed = account.sign_transaction(tx)
+
+    output_payload = {
+        "raw_transaction": signed.rawTransaction.hex(),
+        "transaction_hash": signed.hash.hex(),
+        "from": account.address,
+        "to": SOLO_PRECOMPILE_ADDRESS,
+        "nonce": nonce,
+        "chain_id": args.chain_id,
+        "gas_limit": args.gas_limit,
+        "fee_fields": fee_fields,
+        "claim_specific": args.claim_specific,
+    }
+
+    output_path = Path(args.output)
+    output_path.write_text(json.dumps(output_payload, indent=2))
+
+    if not args.no_stdout:
+        print(output_payload["raw_transaction"])
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a Node.js helper script that wraps and broadcasts claim/claimSpecific calls to the Sei Solo precompile
- support CLI fee configuration, dry-run inspection, and automatic RPC fee detection
- document how to run the helper end-to-end, including secure key handling and broadcasting

## Testing
- node deploy/msg_claim.mjs --help
- node deploy/msg_claim.mjs --payload 0x1234 --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68cffa38cbb08322b3216885b7ee456d