### PR TITLE
feat(nova-portal): add royalty claim UI and API endpoints

### DIFF
--- a/nova_portal/components/RoyaltiesClaimCard.tsx
+++ b/nova_portal/components/RoyaltiesClaimCard.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+interface RoyaltiesClaimCardProps {
+  user: string;
+}
+
+interface CheckResponse {
+  pending: string;
+  error?: string;
+}
+
+interface ClaimResponse {
+  message: string;
+  error?: string;
+}
+
+const formatUsdc = (amount: string) => {
+  try {
+    const bigintAmount = BigInt(amount);
+    const decimals = 6n;
+    const divisor = 10n ** decimals;
+    const whole = bigintAmount / divisor;
+    const fraction = bigintAmount % divisor;
+    const fractionStr = fraction.toString().padStart(Number(decimals), "0").replace(/0+$/, "");
+    return fractionStr ? `${whole.toString()}.${fractionStr}` : whole.toString();
+  } catch (error) {
+    return "0";
+  }
+};
+
+export default function RoyaltiesClaimCard({ user }: RoyaltiesClaimCardProps) {
+  const [pending, setPending] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const check = useCallback(async () => {
+    try {
+      setError(null);
+      setPending(null);
+      const params = new URLSearchParams({ user });
+      const res = await fetch(`/api/check-royalty?${params.toString()}`);
+
+      if (!res.ok) {
+        throw new Error(`Failed to check royalties (${res.status})`);
+      }
+
+      const data: CheckResponse = await res.json();
+
+      if (typeof data.pending !== "string") {
+        throw new Error("Unexpected response from royalty check");
+      }
+
+      setPending(data.pending);
+    } catch (err) {
+      console.error("Failed to check royalties", err);
+      setError(
+        err instanceof Error ? err.message : "Unable to determine pending royalties"
+      );
+      setPending("0");
+    }
+  }, [user]);
+
+  const claim = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const res = await fetch("/api/claim", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ user }),
+      });
+
+      const result: ClaimResponse = await res.json();
+
+      if (!res.ok) {
+        const message = result?.message ?? "Claim request failed";
+        throw new Error(message);
+      }
+
+      alert(result.message);
+      await check();
+    } catch (err) {
+      console.error("Claim request failed", err);
+      const message =
+        err instanceof Error ? err.message : "Unable to submit royalty claim";
+      setError(message);
+      alert(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [check, user]);
+
+  useEffect(() => {
+    if (!user) {
+      setPending("0");
+      return;
+    }
+
+    void check();
+  }, [check, user]);
+
+  return (
+    <div className="mt-4 rounded-lg border border-emerald-200 bg-emerald-50 p-4 shadow-md">
+      <h2 className="text-lg font-semibold">💸 Royalty Claim Portal</h2>
+      {!user && <p className="mt-2 text-sm text-emerald-900">Enter an address to continue.</p>}
+      {error && (
+        <p className="mt-2 text-sm text-red-600" role="alert">
+          {error}
+        </p>
+      )}
+      {pending === null ? (
+        <p className="mt-2 text-sm text-emerald-900">Checking…</p>
+      ) : pending === "0" ? (
+        <p className="mt-2 text-sm text-emerald-900">No unclaimed royalties found.</p>
+      ) : (
+        <div className="mt-2 space-y-2">
+          <p className="text-sm text-emerald-900">
+            Claimable: <strong>{formatUsdc(pending)} USDC</strong>
+          </p>
+          <button
+            className="rounded bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+            disabled={loading}
+            onClick={claim}
+          >
+            {loading ? "Claiming…" : "Claim Now"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/nova_portal/lib/royalties.ts
+++ b/nova_portal/lib/royalties.ts
@@ -1,0 +1,49 @@
+export interface RoyaltyRecord {
+  pending: bigint;
+  messageHash?: string;
+  messageHex?: string;
+  attestationHex?: string;
+}
+
+const normalizeUser = (user: string) => user.trim().toLowerCase();
+
+const seedData: Record<string, RoyaltyRecord> = {
+  "0xabc...": {
+    pending: 2_000_000n,
+    messageHash: "0x1111111111111111111111111111111111111111111111111111111111111111",
+    messageHex: "0x",
+    attestationHex: "0x",
+  },
+  "0xdef...": {
+    pending: 500_000n,
+    messageHash: "0x2222222222222222222222222222222222222222222222222222222222222222",
+    messageHex: "0x",
+    attestationHex: "0x",
+  },
+};
+
+const ledger = new Map<string, RoyaltyRecord>(
+  Object.entries(seedData).map(([address, record]) => [normalizeUser(address), record])
+);
+
+export function getPendingRoyalties(user: string): bigint {
+  const record = ledger.get(normalizeUser(user));
+  return record?.pending ?? 0n;
+}
+
+export function getRoyaltyRecord(user: string): RoyaltyRecord | undefined {
+  return ledger.get(normalizeUser(user));
+}
+
+export function markRoyaltyClaimed(user: string) {
+  const normalized = normalizeUser(user);
+  const record = ledger.get(normalized);
+  if (!record) {
+    return;
+  }
+
+  ledger.set(normalized, {
+    ...record,
+    pending: 0n,
+  });
+}

--- a/nova_portal/pages/api/check-royalty.ts
+++ b/nova_portal/pages/api/check-royalty.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getPendingRoyalties } from "../../lib/royalties";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const { user } = req.query;
+
+  if (!user || Array.isArray(user)) {
+    return res.status(400).json({ error: "Missing user parameter" });
+  }
+
+  const amount = getPendingRoyalties(user);
+  const pending = amount.toString();
+
+  return res.status(200).json({ pending });
+}

--- a/nova_portal/pages/api/claim.ts
+++ b/nova_portal/pages/api/claim.ts
@@ -1,0 +1,108 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { Contract, JsonRpcProvider, Wallet } from "ethers";
+import {
+  getRoyaltyRecord,
+  markRoyaltyClaimed,
+  type RoyaltyRecord,
+} from "../../lib/royalties";
+
+const PROVIDER_URL = process.env.BASE_PROVIDER_URL ?? "https://base.publicnode.com";
+const ROUTER_ADDRESS = process.env.KEEPER_ROYALTY_ROUTER ?? "0xYourKeeperRoyaltyRouter";
+const ABI = ["function settleRoyalty(bytes message, bytes attestation)"];
+
+interface CircleAttestationResponse {
+  status: string;
+  message?: string;
+  attestation?: string;
+}
+
+async function fetchAttestation(record: RoyaltyRecord) {
+  if (!record.messageHash) {
+    return undefined;
+  }
+
+  const response = await fetch(
+    `https://iris-api.circle.com/attestations/${record.messageHash}`
+  );
+
+  if (!response.ok) {
+    throw new Error(`Attestation fetch failed with status ${response.status}`);
+  }
+
+  const data: CircleAttestationResponse = await response.json();
+
+  if (data.status !== "complete" || !data.message || !data.attestation) {
+    throw new Error("Attestation not ready yet");
+  }
+
+  return {
+    messageHex: data.message,
+    attestationHex: data.attestation,
+  };
+}
+
+function assertString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ message: "Method not allowed" });
+  }
+
+  const { user } = req.body ?? {};
+
+  if (!assertString(user)) {
+    return res.status(400).json({ message: "Missing user" });
+  }
+
+  const record = getRoyaltyRecord(user);
+
+  if (!record || record.pending === 0n) {
+    return res.status(404).json({ message: "No pending royalty for this user" });
+  }
+
+  const relayerKey = process.env.RELAYER_PK;
+
+  if (!relayerKey) {
+    markRoyaltyClaimed(user);
+    return res.status(200).json({
+      message:
+        "✅ Simulated royalty claim. Set RELAYER_PK to enable on-chain settlement.",
+    });
+  }
+
+  try {
+    const attestation = await fetchAttestation(record);
+
+    if (!attestation) {
+      return res
+        .status(400)
+        .json({ message: "Missing attestation data for this royalty" });
+    }
+
+    const provider = new JsonRpcProvider(PROVIDER_URL);
+    const wallet = new Wallet(relayerKey, provider);
+    const router = new Contract(ROUTER_ADDRESS, ABI, wallet);
+
+    const tx = await router.settleRoyalty(attestation.messageHex, attestation.attestationHex);
+    await tx.wait();
+
+    markRoyaltyClaimed(user);
+
+    return res.status(200).json({ message: "✅ Royalty claimed!" });
+  } catch (error) {
+    console.error("Claim error:", error);
+
+    const message =
+      error instanceof Error ? error.message : "Failed to claim royalty";
+
+    const status =
+      error instanceof Error && /attestation not ready/i.test(error.message)
+        ? 400
+        : 500;
+
+    return res.status(status).json({ message });
+  }
+}

--- a/nova_portal/pages/index.tsx
+++ b/nova_portal/pages/index.tsx
@@ -1,0 +1,95 @@
+import { FormEvent, useMemo, useState } from "react";
+import RoyaltiesClaimCard from "../components/RoyaltiesClaimCard";
+
+type Address = string;
+
+function normalizeAddress(address: string): Address {
+  return address.trim();
+}
+
+function BalanceCard({ user }: { user: Address }) {
+  const shortAddress = useMemo(() => {
+    if (!user) return "—";
+    return `${user.slice(0, 6)}…${user.slice(-4)}`;
+  }, [user]);
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-slate-900/40 p-4 text-slate-100 shadow-md">
+      <h2 className="text-lg font-semibold">LumenCardVault Balance</h2>
+      <p className="mt-1 text-sm text-slate-300">Linked wallet: {shortAddress}</p>
+      <p className="mt-3 text-2xl font-bold">Coming soon</p>
+    </div>
+  );
+}
+
+function TxHistory({ user }: { user: Address }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-slate-900/40 p-4 text-slate-100 shadow-md">
+      <h2 className="text-lg font-semibold">Recent Flow</h2>
+      <p className="mt-1 text-sm text-slate-300">
+        Sovereign history visualizations will appear here for {user || "your address"}.
+      </p>
+    </div>
+  );
+}
+
+function RoyaltyDashboard() {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-slate-900/40 p-4 text-slate-100 shadow-md">
+      <h2 className="text-lg font-semibold">SolaraKin Sovereign Royalties Terminal</h2>
+      <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-300">
+        <li>Monitor claimable CCTP royalties in real time.</li>
+        <li>Trigger keeper-managed settlements when you are ready.</li>
+        <li>Route flows straight into your LumenCardVault balance.</li>
+      </ul>
+    </div>
+  );
+}
+
+export default function Home() {
+  const [input, setInput] = useState("");
+  const [user, setUser] = useState<Address>("");
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setUser(normalizeAddress(input));
+  };
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-6 text-slate-100">
+      <div className="mx-auto flex max-w-4xl flex-col gap-6">
+        <header className="rounded-lg border border-slate-200 bg-slate-900/60 p-6 text-center shadow-lg">
+          <h1 className="text-3xl font-bold">Nova Portal</h1>
+          <p className="mt-2 text-sm text-slate-300">
+            Manage SolaraKin royalties and track capital routing to your LumenCardVault.
+          </p>
+          <form className="mt-4 flex flex-wrap items-center justify-center gap-3" onSubmit={handleSubmit}>
+            <input
+              className="w-full max-w-md rounded border border-slate-600 bg-slate-950/80 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-emerald-400 focus:outline-none"
+              type="text"
+              placeholder="Enter Sei or Noble wallet"
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+            />
+            <button
+              className="rounded bg-emerald-500 px-4 py-2 text-sm font-medium text-emerald-950 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-emerald-800 disabled:text-emerald-300"
+              type="submit"
+              disabled={!input.trim()}
+            >
+              Load Portal
+            </button>
+          </form>
+        </header>
+
+        {user && (
+          <>
+            <BalanceCard user={user} />
+            <RoyaltiesClaimCard user={user} />
+            <TxHistory user={user} />
+            <RoyaltyDashboard />
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "ethers": "^6.13.1",
+    "next": "^14.2.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   }


### PR DESCRIPTION
## Summary
- add a royalties claim card that surfaces pending amounts and submits claims through the new API
- scaffold the Nova Portal landing page around the claim card alongside balance, history, and dashboard placeholders
- implement royalty check and claim API routes backed by a shared in-memory ledger and optional on-chain settlement, and add Next.js as a dependency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d97cd8e26c83228ecdc052622e43e9