### PR TITLE
Add cross-chain SoulKey test suite

### DIFF
--- a/frontend/__tests__/crossChainAccess.test.js
+++ b/frontend/__tests__/crossChainAccess.test.js
@@ -1,0 +1,103 @@
+const React = require('react');
+const ReactDOM = require('react-dom');
+const TestUtils = require('react-dom/test-utils');
+const CrossChainAccess = require('../components/CrossChainAccess');
+
+describe('CrossChainAccess component', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    if (container) {
+      ReactDOM.unmountComponentAtNode(container);
+      container.remove();
+    }
+    container = null;
+    jest.resetAllMocks();
+    delete global.fetch;
+  });
+
+  test('requests proof and grants vault access on success', async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            proof: ['proof-a', 'proof-b', 'proof-c'],
+            publicSignals: { signalHash: '0xabc', vaultId: 'vault-galaxy' }
+          })
+      })
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ success: true, message: 'Access granted!' })
+      });
+
+    await TestUtils.act(async () => {
+      ReactDOM.render(React.createElement(CrossChainAccess, { user: '0xTestUser' }), container);
+    });
+
+    const button = container.querySelector('[data-testid="request-button"]');
+    expect(button).not.toBeNull();
+
+    await TestUtils.act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const status = container.querySelector('[data-testid="status-message"]');
+    expect(status).not.toBeNull();
+    expect(status.textContent).toBe('Access granted!');
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(global.fetch.mock.calls[0][0]).toBe('/api/soulkey/proof');
+    expect(global.fetch.mock.calls[1][0]).toBe('/api/evm/grant-access');
+  });
+
+  test('notifies user when zk proof submission fails', async () => {
+    global.fetch.mockRejectedValueOnce(new Error('network error'));
+
+    await TestUtils.act(async () => {
+      ReactDOM.render(React.createElement(CrossChainAccess, { user: '0xTestUser' }), container);
+    });
+
+    const button = container.querySelector('[data-testid="request-button"]');
+
+    await TestUtils.act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const status = container.querySelector('[data-testid="status-message"]');
+    expect(status).not.toBeNull();
+    expect(status.textContent).toBe('Unable to complete cross-chain request');
+  });
+
+  test('denies access when verifier returns a failure', async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            proof: ['proof-a', 'proof-b', 'proof-c'],
+            publicSignals: { signalHash: '0xabc', vaultId: 'vault-galaxy' }
+          })
+      })
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ success: false, message: 'Access denied!' })
+      });
+
+    await TestUtils.act(async () => {
+      ReactDOM.render(React.createElement(CrossChainAccess, { user: '0xTestUser' }), container);
+    });
+
+    const button = container.querySelector('[data-testid="request-button"]');
+
+    await TestUtils.act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const status = container.querySelector('[data-testid="status-message"]');
+    expect(status).not.toBeNull();
+    expect(status.textContent).toBe('Access denied!');
+  });
+});

--- a/frontend/components/CrossChainAccess.js
+++ b/frontend/components/CrossChainAccess.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const React = require('react');
+
+const TRANSPORT_BY_CHAIN = {
+  sei: 'ccip',
+  polygon: 'ccip',
+  solana: 'wormhole'
+};
+
+const TARGET_EVM_CHAIN = 'base';
+
+function CrossChainAccess(props) {
+  const { user } = props;
+  const [originChain, setOriginChain] = React.useState('sei');
+  const [status, setStatus] = React.useState('');
+  const [loading, setLoading] = React.useState(false);
+
+  const requestAccess = React.useCallback(async () => {
+    setLoading(true);
+    setStatus('');
+
+    try {
+      const proofResponse = await fetch('/api/soulkey/proof', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          user,
+          originChain,
+          targetChain: TARGET_EVM_CHAIN
+        })
+      });
+
+      const proofPayload = await proofResponse.json();
+      const bridgeResponse = await fetch('/api/evm/grant-access', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          user,
+          originChain,
+          targetChain: TARGET_EVM_CHAIN,
+          transport: TRANSPORT_BY_CHAIN[originChain],
+          proof: proofPayload.proof,
+          publicSignals: proofPayload.publicSignals
+        })
+      });
+
+      const result = await bridgeResponse.json();
+      if (result.success) {
+        setStatus(result.message || 'Access granted!');
+      } else {
+        setStatus(result.message || 'Access denied!');
+      }
+    } catch (error) {
+      setStatus('Unable to complete cross-chain request');
+    } finally {
+      setLoading(false);
+    }
+  }, [user, originChain]);
+
+  return React.createElement(
+    'div',
+    { className: 'cross-chain-access' },
+    React.createElement(
+      'label',
+      { htmlFor: 'origin-chain-select' },
+      'Origin chain'
+    ),
+    React.createElement(
+      'select',
+      {
+        id: 'origin-chain-select',
+        value: originChain,
+        onChange: (event) => setOriginChain(event.target.value),
+        'data-testid': 'origin-chain-select'
+      },
+      Object.keys(TRANSPORT_BY_CHAIN).map((chain) =>
+        React.createElement(
+          'option',
+          { key: chain, value: chain },
+          chain.charAt(0).toUpperCase() + chain.slice(1)
+        )
+      )
+    ),
+    React.createElement(
+      'button',
+      {
+        type: 'button',
+        onClick: requestAccess,
+        disabled: loading,
+        'data-testid': 'request-button'
+      },
+      loading ? 'Requesting access…' : 'Request Vault Access'
+    ),
+    status
+      ? React.createElement(
+          'p',
+          { 'data-testid': 'status-message' },
+          status
+        )
+      : null
+  );
+}
+
+module.exports = CrossChainAccess;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  testMatch: ['**/frontend/__tests__/**/*.test.js'],
+  roots: ['<rootDir>/frontend/__tests__'],
+  moduleFileExtensions: ['js', 'json'],
+  clearMocks: true
+};

--- a/package.json
+++ b/package.json
@@ -2,15 +2,22 @@
   "name": "sei-chain-scripts",
   "version": "1.0.0",
   "private": true,
+  "scripts": {
+    "test:backend": "mocha test/crossChainAccessTest.js",
+    "test:frontend": "jest"
+  },
   "devDependencies": {
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "jest": "^30.1.3",
+    "chai": "^5.1.1",
+    "jest": "^29.7.0",
+    "mocha": "^10.7.3",
     "typescript": "^5.5.4"
   },
   "dependencies": {
     "ethers": "^6.13.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "snarkjs": "^0.7.5"
   }
 }

--- a/test/crossChainAccessTest.js
+++ b/test/crossChainAccessTest.js
@@ -1,0 +1,166 @@
+const { expect } = require('chai');
+const snarkjs = require('snarkjs');
+const { proofFixtures } = require('./fixtures/crossChainProofFixtures');
+
+class MockZkMultiFactorProofVerifier {
+  constructor(fixtures) {
+    this.allowedProofs = new Map(
+      fixtures.map((fixture) => [`${fixture.originChain}:${fixture.user}`, fixture])
+    );
+  }
+
+  async verifyProof(originChain, user, proof, publicSignals) {
+    const fixture = this.allowedProofs.get(`${originChain}:${user}`);
+    if (!fixture) {
+      return false;
+    }
+
+    const proofMatches = fixture.proof.commitment === proof.commitment;
+    const hashMatches = fixture.publicSignals.signalHash === publicSignals.signalHash;
+    const nullifierMatches =
+      snarkjs.bigInt(fixture.publicSignals.nullifier).toString() ===
+      snarkjs.bigInt(publicSignals.nullifier).toString();
+
+    return proofMatches && hashMatches && nullifierMatches;
+  }
+}
+
+class CrossChainSoulKeyGateMock {
+  constructor(verifier) {
+    this.verifier = verifier;
+    this.accessRecords = new Map();
+    this.allowedTransports = {
+      sei: 'ccip',
+      polygon: 'ccip',
+      solana: 'wormhole'
+    };
+  }
+
+  async grantAccessFromCrossChain(request) {
+    const { user, originChain, proof, publicSignals, transport } = request;
+    const expectedTransport = this.allowedTransports[originChain];
+    if (!expectedTransport) {
+      throw new Error(`Unsupported origin chain: ${originChain}`);
+    }
+
+    if (transport !== expectedTransport) {
+      throw new Error(`Invalid transport for ${originChain}`);
+    }
+
+    const valid = await this.verifier.verifyProof(originChain, user, proof, publicSignals);
+    if (!valid) {
+      throw new Error(`Invalid zk proof from ${originChain}`);
+    }
+
+    const normalizedNullifier = snarkjs.bigInt(publicSignals.nullifier).toString();
+    this.accessRecords.set(user, {
+      originChain,
+      targetChain: publicSignals.targetChain,
+      transport,
+      vaultId: publicSignals.vaultId,
+      nullifier: normalizedNullifier,
+      proofCommitment: proof.commitment
+    });
+
+    return true;
+  }
+
+  accessVault(user) {
+    return this.accessRecords.has(user);
+  }
+
+  getAccessRecord(user) {
+    return this.accessRecords.get(user) || null;
+  }
+
+  reset() {
+    this.accessRecords.clear();
+  }
+}
+
+describe('Cross-Chain SoulKey Validation', function () {
+  let gate;
+  let verifier;
+
+  beforeEach(function () {
+    verifier = new MockZkMultiFactorProofVerifier(proofFixtures);
+    gate = new CrossChainSoulKeyGateMock(verifier);
+  });
+
+  afterEach(function () {
+    gate.reset();
+  });
+
+  it('grants access with a valid Sei zk proof via CCIP', async function () {
+    const seiFixture = proofFixtures.find((fixture) => fixture.originChain === 'sei');
+    const request = {
+      user: seiFixture.user,
+      originChain: seiFixture.originChain,
+      proof: { ...seiFixture.proof },
+      publicSignals: { ...seiFixture.publicSignals },
+      transport: seiFixture.transport
+    };
+
+    await gate.grantAccessFromCrossChain(request);
+
+    expect(gate.accessVault(seiFixture.user)).to.equal(true);
+    const record = gate.getAccessRecord(seiFixture.user);
+    expect(record).to.include({
+      originChain: 'sei',
+      targetChain: 'base',
+      transport: 'ccip',
+      vaultId: 'vault-galaxy'
+    });
+    expect(record.nullifier).to.equal('1');
+  });
+
+  it('rejects invalid Solana proofs delivered through Wormhole', async function () {
+    const solanaFixture = proofFixtures.find((fixture) => fixture.originChain === 'solana');
+    const invalidRequest = {
+      user: solanaFixture.user,
+      originChain: solanaFixture.originChain,
+      proof: { commitment: 'tampered-proof' },
+      publicSignals: { ...solanaFixture.publicSignals },
+      transport: solanaFixture.transport
+    };
+
+    try {
+      await gate.grantAccessFromCrossChain(invalidRequest);
+      expect.fail('Expected invalid proof rejection');
+    } catch (error) {
+      expect(error.message).to.include('Invalid zk proof');
+      expect(gate.accessVault(solanaFixture.user)).to.equal(false);
+    }
+  });
+
+  it('confirms multi-chain eligibility for Polygon and Solana SoulKeys', async function () {
+    const polygonFixture = proofFixtures.find((fixture) => fixture.originChain === 'polygon');
+    const solanaFixture = proofFixtures.find((fixture) => fixture.originChain === 'solana');
+
+    await gate.grantAccessFromCrossChain({
+      user: polygonFixture.user,
+      originChain: polygonFixture.originChain,
+      proof: { ...polygonFixture.proof },
+      publicSignals: { ...polygonFixture.publicSignals },
+      transport: polygonFixture.transport
+    });
+
+    await gate.grantAccessFromCrossChain({
+      user: solanaFixture.user,
+      originChain: solanaFixture.originChain,
+      proof: { ...solanaFixture.proof },
+      publicSignals: { ...solanaFixture.publicSignals },
+      transport: solanaFixture.transport
+    });
+
+    const polygonRecord = gate.getAccessRecord(polygonFixture.user);
+    const solanaRecord = gate.getAccessRecord(solanaFixture.user);
+
+    expect(polygonRecord.targetChain).to.equal('arbitrum');
+    expect(solanaRecord.targetChain).to.equal('base');
+    expect(polygonRecord.transport).to.equal('ccip');
+    expect(solanaRecord.transport).to.equal('wormhole');
+    expect(gate.accessVault(polygonFixture.user)).to.equal(true);
+    expect(gate.accessVault(solanaFixture.user)).to.equal(true);
+  });
+});

--- a/test/fixtures/crossChainProofFixtures.js
+++ b/test/fixtures/crossChainProofFixtures.js
@@ -1,0 +1,57 @@
+const { createHash } = require('crypto');
+
+function createSignalHash(user, originChain, vaultId) {
+  return createHash('sha256')
+    .update(`${user.toLowerCase()}:${originChain}:${vaultId}`)
+    .digest('hex');
+}
+
+const proofFixtures = [
+  {
+    label: 'sei-to-base',
+    user: '0xSeiSoulKeyUser',
+    originChain: 'sei',
+    vaultId: 'vault-galaxy',
+    proof: { commitment: 'sei-proof-root' },
+    publicSignals: {
+      signalHash: createSignalHash('0xSeiSoulKeyUser', 'sei', 'vault-galaxy'),
+      targetChain: 'base',
+      nullifier: '1',
+      vaultId: 'vault-galaxy'
+    },
+    transport: 'ccip'
+  },
+  {
+    label: 'polygon-to-arbitrum',
+    user: '0xPolygonSoulKeyUser',
+    originChain: 'polygon',
+    vaultId: 'vault-galaxy',
+    proof: { commitment: 'polygon-proof-root' },
+    publicSignals: {
+      signalHash: createSignalHash('0xPolygonSoulKeyUser', 'polygon', 'vault-galaxy'),
+      targetChain: 'arbitrum',
+      nullifier: '2',
+      vaultId: 'vault-galaxy'
+    },
+    transport: 'ccip'
+  },
+  {
+    label: 'solana-to-base',
+    user: 'So1anaSoulKeyUser1111111111111111111111111',
+    originChain: 'solana',
+    vaultId: 'vault-galaxy',
+    proof: { commitment: 'solana-proof-root' },
+    publicSignals: {
+      signalHash: createSignalHash('So1anaSoulKeyUser1111111111111111111111111', 'solana', 'vault-galaxy'),
+      targetChain: 'base',
+      nullifier: '3',
+      vaultId: 'vault-galaxy'
+    },
+    transport: 'wormhole'
+  }
+];
+
+module.exports = {
+  proofFixtures,
+  createSignalHash
+};


### PR DESCRIPTION
## Summary
- add npm scripts to run backend and frontend cross-chain test suites
- implement mocha-based mock SoulKey gate tests with snarkjs-backed fixtures for Sei, Polygon, and Solana flows
- provide a React-based access request widget with accompanying Jest tests and configuration

## Testing
- not run (npm install blocked by registry 403)


------
https://chatgpt.com/codex/tasks/task_e_68d97e9872608322ad12a5e925aec8d0