### PR TITLE
Add cross-chain SoulKey access test suite

### DIFF
--- a/contracts/src/CrossChainSoulKeyGate.sol
+++ b/contracts/src/CrossChainSoulKeyGate.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title CrossChainSoulKeyGate
+/// @notice Validates zero-knowledge proofs that arrive from external chains and
+///         persists vault access eligibility for a given account.
+interface IZkMultiFactorProofVerifier {
+    function verify(bytes calldata proof, bytes calldata publicSignals) external view returns (bool);
+}
+
+contract CrossChainSoulKeyGate {
+    IZkMultiFactorProofVerifier public immutable verifier;
+    address public immutable messageTransmitter;
+
+    mapping(address => bool) private _vaultAccess;
+    mapping(address => mapping(bytes32 => bool)) private _chainAccess;
+    mapping(address => bytes32[]) private _chainHistory;
+
+    event CrossChainAccessGranted(
+        address indexed account,
+        bytes32 indexed sourceChain,
+        bytes32 proofHash
+    );
+
+    constructor(address verifierAddress, address transmitter) {
+        require(verifierAddress != address(0), "Verifier required");
+        require(transmitter != address(0), "Transmitter required");
+
+        verifier = IZkMultiFactorProofVerifier(verifierAddress);
+        messageTransmitter = transmitter;
+    }
+
+    function grantAccessFromCrossChain(
+        address account,
+        bytes32 sourceChain,
+        bytes calldata proof,
+        bytes calldata publicSignals
+    ) external {
+        require(msg.sender == messageTransmitter, "Unauthorized message transmitter");
+        require(verifier.verify(proof, publicSignals), "Invalid zk proof");
+
+        _vaultAccess[account] = true;
+        if (!_chainAccess[account][sourceChain]) {
+            _chainAccess[account][sourceChain] = true;
+            _chainHistory[account].push(sourceChain);
+        }
+
+        emit CrossChainAccessGranted(account, sourceChain, keccak256(abi.encodePacked(proof, publicSignals)));
+    }
+
+    function hasVaultAccess(address account) external view returns (bool) {
+        return _vaultAccess[account];
+    }
+
+    function hasChainAccess(address account, bytes32 sourceChain) external view returns (bool) {
+        return _chainAccess[account][sourceChain];
+    }
+
+    function getAccessChains(address account) external view returns (bytes32[] memory) {
+        return _chainHistory[account];
+    }
+}

--- a/contracts/src/MockZkMultiFactorProofVerifier.sol
+++ b/contracts/src/MockZkMultiFactorProofVerifier.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IZkMultiFactorProofVerifier} from "./CrossChainSoulKeyGate.sol";
+
+contract MockZkMultiFactorProofVerifier is IZkMultiFactorProofVerifier {
+    mapping(bytes32 => bool) private _verificationResults;
+
+    function setVerificationResult(bytes calldata proof, bytes calldata publicSignals, bool result) external {
+        _verificationResults[_key(proof, publicSignals)] = result;
+    }
+
+    function verify(bytes calldata proof, bytes calldata publicSignals) external view override returns (bool) {
+        return _verificationResults[_key(proof, publicSignals)];
+    }
+
+    function _key(bytes calldata proof, bytes calldata publicSignals) private pure returns (bytes32) {
+        return keccak256(abi.encodePacked(proof, publicSignals));
+    }
+}

--- a/contracts/test/CrossChainSoulKeyAccess.test.js
+++ b/contracts/test/CrossChainSoulKeyAccess.test.js
@@ -1,0 +1,97 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("CrossChainSoulKeyGate", function () {
+  let owner;
+  let user;
+  let gateContract;
+  let verifierContract;
+
+  const toBytes = (value) => ethers.hexlify(ethers.toUtf8Bytes(value));
+  const chainId = (name) => ethers.id(name);
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+
+    const Verifier = await ethers.getContractFactory("MockZkMultiFactorProofVerifier");
+    verifierContract = await Verifier.deploy();
+
+    const Gate = await ethers.getContractFactory("CrossChainSoulKeyGate");
+    gateContract = await Gate.deploy(await verifierContract.getAddress(), owner.address);
+  });
+
+  it("grants access with a valid Sei proof", async function () {
+    const proof = toBytes("sei-proof");
+    const publicSignals = toBytes("sei-public");
+    const sourceChain = chainId("sei");
+
+    await verifierContract.setVerificationResult(proof, publicSignals, true);
+
+    await expect(
+      gateContract
+        .connect(owner)
+        .grantAccessFromCrossChain(user.address, sourceChain, proof, publicSignals)
+    )
+      .to.emit(gateContract, "CrossChainAccessGranted")
+      .withArgs(
+        user.address,
+        sourceChain,
+        ethers.keccak256(ethers.concat([proof, publicSignals]))
+      );
+
+    expect(await gateContract.hasVaultAccess(user.address)).to.equal(true);
+    expect(await gateContract.hasChainAccess(user.address, sourceChain)).to.equal(true);
+
+    const chains = await gateContract.getAccessChains(user.address);
+    expect(chains).to.deep.equal([sourceChain]);
+  });
+
+  it("rejects invalid proofs from Solana", async function () {
+    const proof = toBytes("invalid-solana-proof");
+    const publicSignals = toBytes("invalid-signal");
+    const sourceChain = chainId("solana");
+
+    await expect(
+      gateContract
+        .connect(owner)
+        .grantAccessFromCrossChain(user.address, sourceChain, proof, publicSignals)
+    ).to.be.revertedWith("Invalid zk proof");
+  });
+
+  it("tracks multi-chain eligibility across Sei, Polygon, and Solana", async function () {
+    const seiProof = toBytes("sei-proof");
+    const seiSignals = toBytes("sei-signal");
+    const polygonProof = toBytes("polygon-proof");
+    const polygonSignals = toBytes("polygon-signal");
+    const solanaProof = toBytes("solana-proof");
+    const solanaSignals = toBytes("solana-signal");
+
+    const sei = chainId("sei");
+    const polygon = chainId("polygon");
+    const solana = chainId("solana");
+
+    await verifierContract.setVerificationResult(seiProof, seiSignals, true);
+    await gateContract
+      .connect(owner)
+      .grantAccessFromCrossChain(user.address, sei, seiProof, seiSignals);
+
+    await verifierContract.setVerificationResult(polygonProof, polygonSignals, true);
+    await gateContract
+      .connect(owner)
+      .grantAccessFromCrossChain(user.address, polygon, polygonProof, polygonSignals);
+
+    await verifierContract.setVerificationResult(solanaProof, solanaSignals, true);
+    await gateContract
+      .connect(owner)
+      .grantAccessFromCrossChain(user.address, solana, solanaProof, solanaSignals);
+
+    expect(await gateContract.hasVaultAccess(user.address)).to.equal(true);
+    expect(await gateContract.hasChainAccess(user.address, sei)).to.equal(true);
+    expect(await gateContract.hasChainAccess(user.address, polygon)).to.equal(true);
+    expect(await gateContract.hasChainAccess(user.address, solana)).to.equal(true);
+
+    const chains = await gateContract.getAccessChains(user.address);
+    expect(chains).to.have.lengthOf(3);
+    expect(chains).to.include.members([sei, polygon, solana]);
+  });
+});

--- a/tests/cross-chain/README.md
+++ b/tests/cross-chain/README.md
@@ -1,0 +1,12 @@
+# Cross-Chain Testing Suite
+
+This package contains a standalone Jest test harness that exercises the front-end surface area of the cross-chain proof flow.  It mocks zero-knowledge proof retrieval and simulates bridge relays for Sei, Polygon, Solana, and EVM chains.
+
+## Usage
+
+```bash
+npm install
+npm test
+```
+
+The suite relies on mocked fetch responses to emulate CCIP and Wormhole relayers.  The fixtures align with the Hardhat tests that live in `contracts/test/CrossChainSoulKeyAccess.test.js`.

--- a/tests/cross-chain/jest.config.ts
+++ b/tests/cross-chain/jest.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  preset: "ts-jest",
+  testEnvironment: "jsdom",
+  roots: ["<rootDir>/src"],
+  setupFilesAfterEnv: ["<rootDir>/src/setupTests.ts"],
+  moduleFileExtensions: ["ts", "tsx", "js"],
+  clearMocks: true
+};
+
+export default config;

--- a/tests/cross-chain/package.json
+++ b/tests/cross-chain/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "cross-chain-testing-suite",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "jest --runInBand"
+  },
+  "dependencies": {
+    "ethers": "^6.14.4",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "snarkjs": "^0.7.3"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.0",
+    "@testing-library/react": "^14.3.1",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.12.12",
+    "@types/react": "^18.3.8",
+    "@types/react-dom": "^18.3.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.4.5"
+  }
+}

--- a/tests/cross-chain/src/__tests__/crossChainAccess.test.tsx
+++ b/tests/cross-chain/src/__tests__/crossChainAccess.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import CrossChainAccess from "../components/CrossChainAccess";
+
+describe("CrossChainAccess", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("allows a user to request vault access successfully", async () => {
+    const mockFetch = jest.fn()
+      .mockResolvedValueOnce({
+        json: async () => ({ proof: "0xproof", publicSignals: "0xsignals" })
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({ success: true, message: "Access granted!" })
+      });
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    render(<CrossChainAccess user="0xTestUserAddress" />);
+
+    const button = screen.getByRole("button", { name: /request vault access/i });
+    fireEvent.click(button);
+
+    const successMessage = await screen.findByText(/Access granted!/i);
+    expect(successMessage).toBeInTheDocument();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces an error when the proof is invalid", async () => {
+    const mockFetch = jest.fn()
+      .mockResolvedValueOnce({
+        json: async () => ({ proof: "0xinvalid", publicSignals: "0xsignals" })
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({ success: false, message: "Access denied!" })
+      });
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    render(<CrossChainAccess user="0xTestUserAddress" />);
+
+    const button = screen.getByRole("button", { name: /request vault access/i });
+    fireEvent.click(button);
+
+    const errorMessage = await screen.findByText(/Access denied!/i);
+    expect(errorMessage).toBeInTheDocument();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("sends chain metadata when requesting access from polygon", async () => {
+    const mockFetch = jest.fn()
+      .mockResolvedValueOnce({
+        json: async () => ({ proof: "0xpolygon", publicSignals: "0xpolygon-signals" })
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({ success: true, message: "Access granted!" })
+      });
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    render(<CrossChainAccess user="0xTestUserAddress" />);
+
+    fireEvent.change(screen.getByTestId("chain-select"), { target: { value: "polygon" } });
+    fireEvent.click(screen.getByRole("button", { name: /request vault access/i }));
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
+
+    const [, secondCall] = mockFetch.mock.calls;
+    const requestBody = JSON.parse(secondCall[1].body as string);
+    expect(requestBody.sourceChain).toEqual("polygon");
+    expect(requestBody.user).toEqual("0xTestUserAddress");
+  });
+});

--- a/tests/cross-chain/src/components/CrossChainAccess.tsx
+++ b/tests/cross-chain/src/components/CrossChainAccess.tsx
@@ -1,0 +1,88 @@
+import { useCallback, useMemo, useState } from "react";
+
+type CrossChainAccessProps = {
+  user: string;
+};
+
+type ProofResponse = {
+  proof: string;
+  publicSignals: string;
+};
+
+type AccessResponse = {
+  success: boolean;
+  message: string;
+};
+
+const SUPPORTED_CHAINS = [
+  "sei",
+  "polygon",
+  "solana",
+  "base",
+  "arbitrum",
+  "ethereum"
+];
+
+export default function CrossChainAccess({ user }: CrossChainAccessProps) {
+  const [chain, setChain] = useState<string>("sei");
+  const [message, setMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const chains = useMemo(() => SUPPORTED_CHAINS, []);
+
+  const requestAccess = useCallback(async () => {
+    setLoading(true);
+    setMessage(null);
+
+    try {
+      const proofResponse = await fetch("/api/zk-proof", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ user, sourceChain: chain })
+      });
+      const proofPayload = (await proofResponse.json()) as ProofResponse;
+
+      const accessResponse = await fetch("/api/cross-chain-access", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          user,
+          sourceChain: chain,
+          proof: proofPayload.proof,
+          publicSignals: proofPayload.publicSignals
+        })
+      });
+
+      const accessPayload = (await accessResponse.json()) as AccessResponse;
+      setMessage(accessPayload.message);
+    } catch (err) {
+      setMessage("Access denied!");
+    } finally {
+      setLoading(false);
+    }
+  }, [chain, user]);
+
+  return (
+    <div>
+      <label htmlFor="chain-select">Source chain</label>
+      <select
+        id="chain-select"
+        data-testid="chain-select"
+        value={chain}
+        onChange={(event) => setChain(event.target.value)}
+      >
+        {chains.map((name) => (
+          <option key={name} value={name}>
+            {name}
+          </option>
+        ))}
+      </select>
+
+      <button onClick={requestAccess} disabled={loading}>
+        {loading ? "Requesting..." : "Request Vault Access"}
+      </button>
+
+      {message && <p>{message}</p>}
+    </div>
+  );
+}

--- a/tests/cross-chain/src/setupTests.ts
+++ b/tests/cross-chain/src/setupTests.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/tests/cross-chain/tsconfig.json
+++ b/tests/cross-chain/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx",
+    "types": ["jest", "node"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add a CrossChainSoulKeyGate contract with a mock verifier to model cross-chain proof verification
- create Hardhat tests that exercise Sei, Polygon, and Solana proof flows and ensure vault access tracking
- scaffold a Jest-based frontend harness for requesting cross-chain vault access and verifying request payloads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d97e9872608322ad12a5e925aec8d0