### PR TITLE
Rebrand DAP keeper flow to Sei Pipeline (remove runtime naming)

### DIFF
--- a/scripts/dap-devnet.sh
+++ b/scripts/dap-devnet.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "⚙️  This scaffold expects the existing Sei localnet tooling."
+echo "Use: make localnet-start"

--- a/scripts/dap-run-dev.sh
+++ b/scripts/dap-run-dev.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "🚀 Building seid (Sei native node)"
+make build
+
+echo "🌀 Starting local Sei node with DAP scaffold context"
+./build/seid start --home ./build/dap-dev --log_level info

--- a/scripts/dap-zk-proof.sh
+++ b/scripts/dap-zk-proof.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXTRINSIC=${1:-tx}
+PRE=${2:-pre}
+POST=${3:-post}
+
+echo "🔐 DAP zk placeholder receipt"
+go test ./x/dap/... -run TestPipelineExecuteSuccess -count=1 >/dev/null
+echo "inputs: extrinsic=${EXTRINSIC} pre=${PRE} post=${POST}"

--- a/x/dap/README.md
+++ b/x/dap/README.md
@@ -1,0 +1,27 @@
+# DAP (Dynamic Allocation Pool) — Sei Native Go Scaffold
+
+This directory contains a **Sei-native Go DAP scaffold** focused on modular pipeline stages
+that are easy to wire into Cosmos SDK keeper/message flows.
+
+- `keeper/pipeline.go` → ordered DAP pipeline execution for transaction envelopes
+- `types/` → module constants and event names
+- `zk/circuit.go` → circuit witness container
+- `zk/proof.go` → deterministic proof receipt hash helper
+
+## Stage mapping
+
+- `dap_guard` -> `GuardVerifier`
+- `origin_verifier` -> `OriginResolver`
+- `signal_sync` -> `SignalSynchronizer`
+- `soulsync` -> `SoulLocker`
+- `genzk402` -> `ZKSealer`
+
+This scaffold is intentionally lightweight and Sei-oriented so it can be expanded with
+Msg handlers, keeper storage, params, and gRPC surfaces without introducing consensus risk.
+
+## What was missing and now added
+
+- Pipeline constructor validation for nil dependencies (guard/origin/signal/soul/zk sealer).
+- Input validation for empty actor IDs before stage execution.
+- Wrapped stage-specific errors to make failures easier to diagnose in production logs.
+- A parallel stress test (`TestPipelineExecuteStress`) that drives the flow across many goroutines and verifies every receipt is sealed.

--- a/x/dap/keeper/pipeline.go
+++ b/x/dap/keeper/pipeline.go
@@ -1,0 +1,105 @@
+package keeper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/sei-protocol/sei-chain/x/dap/zk"
+)
+
+var (
+	ErrNilGuard    = errors.New("dap pipeline guard verifier is nil")
+	ErrNilOrigin   = errors.New("dap pipeline origin resolver is nil")
+	ErrNilSignal   = errors.New("dap pipeline signal synchronizer is nil")
+	ErrNilSoul     = errors.New("dap pipeline soul locker is nil")
+	ErrNilZKSealer = errors.New("dap pipeline zk sealer is nil")
+	ErrEmptyActor  = errors.New("dap pipeline actor is empty")
+)
+
+// GuardVerifier checks transition authenticity.
+type GuardVerifier interface {
+	Guard(ctx context.Context, actor string, extrinsic []byte) error
+}
+
+// OriginResolver resolves request provenance.
+type OriginResolver interface {
+	Resolve(ctx context.Context, actor string) error
+}
+
+// SignalSynchronizer emits non-blocking governance signal sync.
+type SignalSynchronizer interface {
+	Sync(ctx context.Context, actor string) error
+}
+
+// SoulLocker applies spoof-prevention entropy lock semantics.
+type SoulLocker interface {
+	Lock(ctx context.Context, actor string) error
+}
+
+// ZKSealer stores or relays proof artifacts.
+type ZKSealer interface {
+	Seal(ctx context.Context, actor string, receipt [32]byte) error
+}
+
+// Pipeline orchestrates DAP flow for a single transaction envelope.
+type Pipeline struct {
+	guard  GuardVerifier
+	origin OriginResolver
+	signal SignalSynchronizer
+	soul   SoulLocker
+	zk     ZKSealer
+}
+
+func NewPipeline(
+	guard GuardVerifier,
+	origin OriginResolver,
+	signal SignalSynchronizer,
+	soul SoulLocker,
+	zkSealer ZKSealer,
+) (Pipeline, error) {
+	if guard == nil {
+		return Pipeline{}, ErrNilGuard
+	}
+	if origin == nil {
+		return Pipeline{}, ErrNilOrigin
+	}
+	if signal == nil {
+		return Pipeline{}, ErrNilSignal
+	}
+	if soul == nil {
+		return Pipeline{}, ErrNilSoul
+	}
+	if zkSealer == nil {
+		return Pipeline{}, ErrNilZKSealer
+	}
+
+	return Pipeline{guard: guard, origin: origin, signal: signal, soul: soul, zk: zkSealer}, nil
+}
+
+// Execute runs the DAP sequence and returns a deterministic receipt hash.
+func (p Pipeline) Execute(ctx context.Context, actor string, extrinsic, preState, postState []byte) ([32]byte, error) {
+	if actor == "" {
+		return [32]byte{}, ErrEmptyActor
+	}
+
+	if err := p.guard.Guard(ctx, actor, extrinsic); err != nil {
+		return [32]byte{}, fmt.Errorf("guard verification failed: %w", err)
+	}
+	if err := p.origin.Resolve(ctx, actor); err != nil {
+		return [32]byte{}, fmt.Errorf("origin resolution failed: %w", err)
+	}
+	if err := p.signal.Sync(ctx, actor); err != nil {
+		return [32]byte{}, fmt.Errorf("signal synchronization failed: %w", err)
+	}
+	if err := p.soul.Lock(ctx, actor); err != nil {
+		return [32]byte{}, fmt.Errorf("soul lock failed: %w", err)
+	}
+
+	receipt := zk.GenerateReceiptHash(extrinsic, preState, postState)
+	if err := p.zk.Seal(ctx, actor, receipt); err != nil {
+		return [32]byte{}, fmt.Errorf("zk seal failed: %w", err)
+	}
+
+	return receipt, nil
+}

--- a/x/dap/keeper/pipeline_test.go
+++ b/x/dap/keeper/pipeline_test.go
@@ -1,0 +1,178 @@
+package keeper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+type noopGuard struct{ err error }
+
+func (n noopGuard) Guard(_ context.Context, _ string, _ []byte) error { return n.err }
+
+type noopOrigin struct{ err error }
+
+func (n noopOrigin) Resolve(_ context.Context, _ string) error { return n.err }
+
+type noopSignal struct{ err error }
+
+func (n noopSignal) Sync(_ context.Context, _ string) error { return n.err }
+
+type noopSoul struct{ err error }
+
+func (n noopSoul) Lock(_ context.Context, _ string) error { return n.err }
+
+type captureZK struct {
+	err     error
+	sealed  bool
+	receipt [32]byte
+}
+
+func (c *captureZK) Seal(_ context.Context, _ string, receipt [32]byte) error {
+	if c.err != nil {
+		return c.err
+	}
+	c.sealed = true
+	c.receipt = receipt
+	return nil
+}
+
+type syncCapture struct {
+	sealedCount *atomic.Int64
+}
+
+func (s syncCapture) Seal(_ context.Context, _ string, _ [32]byte) error {
+	s.sealedCount.Add(1)
+	return nil
+}
+
+func mustPipeline(t *testing.T, guard GuardVerifier, origin OriginResolver, signal SignalSynchronizer, soul SoulLocker, zkSealer ZKSealer) Pipeline {
+	t.Helper()
+	p, err := NewPipeline(guard, origin, signal, soul, zkSealer)
+	if err != nil {
+		t.Fatalf("NewPipeline failed: %v", err)
+	}
+	return p
+}
+
+func TestNewPipelineNilDependency(t *testing.T) {
+	cases := []struct {
+		name     string
+		guard    GuardVerifier
+		origin   OriginResolver
+		signal   SignalSynchronizer
+		soul     SoulLocker
+		zkSealer ZKSealer
+		err      error
+	}{
+		{name: "nil guard", origin: noopOrigin{}, signal: noopSignal{}, soul: noopSoul{}, zkSealer: &captureZK{}, err: ErrNilGuard},
+		{name: "nil origin", guard: noopGuard{}, signal: noopSignal{}, soul: noopSoul{}, zkSealer: &captureZK{}, err: ErrNilOrigin},
+		{name: "nil signal", guard: noopGuard{}, origin: noopOrigin{}, soul: noopSoul{}, zkSealer: &captureZK{}, err: ErrNilSignal},
+		{name: "nil soul", guard: noopGuard{}, origin: noopOrigin{}, signal: noopSignal{}, zkSealer: &captureZK{}, err: ErrNilSoul},
+		{name: "nil zk", guard: noopGuard{}, origin: noopOrigin{}, signal: noopSignal{}, soul: noopSoul{}, err: ErrNilZKSealer},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewPipeline(tc.guard, tc.origin, tc.signal, tc.soul, tc.zkSealer)
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("expected %v, got %v", tc.err, err)
+			}
+		})
+	}
+}
+
+func TestPipelineExecuteSuccess(t *testing.T) {
+	zkSealer := &captureZK{}
+	p := mustPipeline(t, noopGuard{}, noopOrigin{}, noopSignal{}, noopSoul{}, zkSealer)
+
+	receipt, err := p.Execute(context.Background(), "sei1actor", []byte("tx"), []byte("pre"), []byte("post"))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if !zkSealer.sealed {
+		t.Fatal("expected zk receipt to be sealed")
+	}
+	if zkSealer.receipt != receipt {
+		t.Fatal("expected returned receipt to equal sealed receipt")
+	}
+}
+
+func TestPipelineExecuteRejectsEmptyActor(t *testing.T) {
+	p := mustPipeline(t, noopGuard{}, noopOrigin{}, noopSignal{}, noopSoul{}, &captureZK{})
+
+	_, err := p.Execute(context.Background(), "", []byte("tx"), []byte("pre"), []byte("post"))
+	if !errors.Is(err, ErrEmptyActor) {
+		t.Fatalf("expected empty actor error, got %v", err)
+	}
+}
+
+func TestPipelineExecuteErrorWrapping(t *testing.T) {
+	guardErr := errors.New("guard failed")
+	originErr := errors.New("origin failed")
+	signalErr := errors.New("signal failed")
+	soulErr := errors.New("soul failed")
+	zkErr := errors.New("zk failed")
+
+	cases := []struct {
+		name       string
+		pipeline   Pipeline
+		rootErr    error
+		wantPrefix string
+	}{
+		{name: "guard", pipeline: mustPipeline(t, noopGuard{err: guardErr}, noopOrigin{}, noopSignal{}, noopSoul{}, &captureZK{}), rootErr: guardErr, wantPrefix: "guard verification failed"},
+		{name: "origin", pipeline: mustPipeline(t, noopGuard{}, noopOrigin{err: originErr}, noopSignal{}, noopSoul{}, &captureZK{}), rootErr: originErr, wantPrefix: "origin resolution failed"},
+		{name: "signal", pipeline: mustPipeline(t, noopGuard{}, noopOrigin{}, noopSignal{err: signalErr}, noopSoul{}, &captureZK{}), rootErr: signalErr, wantPrefix: "signal synchronization failed"},
+		{name: "soul", pipeline: mustPipeline(t, noopGuard{}, noopOrigin{}, noopSignal{}, noopSoul{err: soulErr}, &captureZK{}), rootErr: soulErr, wantPrefix: "soul lock failed"},
+		{name: "zk", pipeline: mustPipeline(t, noopGuard{}, noopOrigin{}, noopSignal{}, noopSoul{}, &captureZK{err: zkErr}), rootErr: zkErr, wantPrefix: "zk seal failed"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.pipeline.Execute(context.Background(), "sei1actor", []byte("tx"), []byte("pre"), []byte("post"))
+			if err == nil {
+				t.Fatalf("expected an error")
+			}
+			if !errors.Is(err, tc.rootErr) {
+				t.Fatalf("expected wrapped root error %v, got %v", tc.rootErr, err)
+			}
+			if !strings.HasPrefix(err.Error(), tc.wantPrefix) {
+				t.Fatalf("expected prefix %q in error %q", tc.wantPrefix, err)
+			}
+		})
+	}
+}
+
+func TestPipelineExecuteStress(t *testing.T) {
+	const workers = 64
+	const iterationsPerWorker = 200
+
+	sealedCount := &atomic.Int64{}
+	p := mustPipeline(t, noopGuard{}, noopOrigin{}, noopSignal{}, noopSoul{}, syncCapture{sealedCount: sealedCount})
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for worker := 0; worker < workers; worker++ {
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < iterationsPerWorker; i++ {
+				actor := fmt.Sprintf("sei1actor%d", worker)
+				extrinsic := []byte(fmt.Sprintf("tx-%d-%d", worker, i))
+				if _, err := p.Execute(context.Background(), actor, extrinsic, []byte("pre"), []byte("post")); err != nil {
+					t.Errorf("unexpected error on worker %d iteration %d: %v", worker, i, err)
+					return
+				}
+			}
+		}(worker)
+	}
+
+	wg.Wait()
+	want := int64(workers * iterationsPerWorker)
+	if got := sealedCount.Load(); got != want {
+		t.Fatalf("expected %d sealed receipts, got %d", want, got)
+	}
+}

--- a/x/dap/types/events.go
+++ b/x/dap/types/events.go
@@ -1,0 +1,9 @@
+package types
+
+const (
+	EventTypeGuarded            = "dap_guarded"
+	EventTypeProvenanceResolved = "dap_provenance_resolved"
+	EventTypeSignalSynced       = "dap_signal_synced"
+	EventTypeSoulLocked         = "dap_soul_locked"
+	EventTypeProofSealed        = "dap_proof_sealed"
+)

--- a/x/dap/types/keys.go
+++ b/x/dap/types/keys.go
@@ -1,0 +1,6 @@
+package types
+
+const (
+	// ModuleName defines the module name for DAP.
+	ModuleName = "dap"
+)

--- a/x/dap/zk/circuit.go
+++ b/x/dap/zk/circuit.go
@@ -1,0 +1,8 @@
+package zk
+
+// PPLCircuit is a simple witness container for a future zk-SNARK circuit backend.
+type PPLCircuit struct {
+	PreState      []byte
+	PostState     []byte
+	ExtrinsicHash []byte
+}

--- a/x/dap/zk/proof.go
+++ b/x/dap/zk/proof.go
@@ -1,0 +1,14 @@
+package zk
+
+import "crypto/sha256"
+
+// GenerateReceiptHash returns a deterministic 32-byte receipt hash from
+// extrinsic payload + pre-state + post-state. This is a local placeholder
+// for future Halo2/Risc0 proof materialization.
+func GenerateReceiptHash(extrinsic, preState, postState []byte) [32]byte {
+	payload := make([]byte, 0, len(extrinsic)+len(preState)+len(postState))
+	payload = append(payload, extrinsic...)
+	payload = append(payload, preState...)
+	payload = append(payload, postState...)
+	return sha256.Sum256(payload)
+}


### PR DESCRIPTION
### Motivation

- Align the DAP scaffold with Sei/Cosmos SDK naming by removing "runtime"-oriented terminology and replacing it with a pipeline-oriented API.
- Provide a small, clear keeper/pipeline execution surface and lightweight zk helper artifacts to make the scaffold easier to wire into Sei keeper/msg flows.

### Description

- Renamed the keeper execution surface from `Runtime` → `Pipeline`, `NewRuntime` → `NewPipeline`, and `Process` → `Execute` by moving `x/dap/keeper/runtime.go` → `x/dap/keeper/pipeline.go` and updating all references.
- Updated unit tests to match the new API by renaming `runtime_test.go` → `pipeline_test.go` and converting test names/calls to `NewPipeline`/`Execute`/`TestPipeline*` semantics.
- Added small infrastructure and docs: `x/dap/README.md` (Sei-oriented), `x/dap/types/events.go`, `x/dap/types/keys.go`, `x/dap/zk/circuit.go`, and `x/dap/zk/proof.go` (deterministic receipt hash helper).
- Updated dev scripts to reference the renamed test and included simple dev helpers: `scripts/dap-zk-proof.sh`, `scripts/dap-run-dev.sh`, and `scripts/dap-devnet.sh`.

### Testing

- Ran `gofmt -w x/dap/keeper/pipeline.go x/dap/keeper/pipeline_test.go` which succeeded.
- Attempted `go test ./x/dap/...` but it failed in this environment due to a Go toolchain mismatch (`go.work` requires `>= 1.24.5`, local is `1.24.3`).
- Attempted `GOTOOLCHAIN=auto go test ./x/dap/...` but the toolchain download was blocked by the environment (proxy download forbidden), so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c32ac8f508322aa47cc6cef19f7fa)