### PR TITLE
test(statesync): replace sleep-based wait with condition polling helper

### DIFF
--- a/sei-tendermint/internal/statesync/syncer_test.go
+++ b/sei-tendermint/internal/statesync/syncer_test.go
@@ -577,7 +577,9 @@ func TestSyncer_applyChunks_RefetchChunks(t *testing.T) {
 				rts.reactor.syncer.applyChunks(ctx, chunks, fetchStartTime) //nolint:errcheck // purposefully ignore error
 			}()
 
-			waitForChunk(t, chunks, 0, 2*time.Second)
+			waitForCondition(t, 2*time.Second, func() bool {
+				return !chunks.Has(1)
+			}, "chunk 1 to be removed")
 			require.False(t, chunks.Has(1))
 			require.True(t, chunks.Has(2))
 
@@ -750,20 +752,15 @@ func toABCI(s *snapshot) *abci.Snapshot {
 	}
 }
 
-func waitForChunk(
-    t *testing.T,
-    chunks *ChunkStore,
-    index uint32,
-    timeout time.Duration,
-) {
-    t.Helper()
+func waitForCondition(t *testing.T, timeout time.Duration, condition func() bool, conditionDescription string) {
+	t.Helper()
 
-    deadline := time.Now().Add(timeout)
-    for time.Now().Before(deadline) {
-        if chunks.Has(index) {
-            return
-        }
-        time.Sleep(5 * time.Millisecond)
-    }
-    t.Fatalf("chunk %d not received before timeout", index)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", conditionDescription)
 }

--- a/sei-tendermint/internal/statesync/syncer_test.go
+++ b/sei-tendermint/internal/statesync/syncer_test.go
@@ -580,6 +580,7 @@ func TestSyncer_applyChunks_RefetchChunks(t *testing.T) {
 			waitForCondition(t, 2*time.Second, func() bool {
 				return !chunks.Has(1)
 			}, "chunk 1 to be removed")
+			require.True(t, chunks.Has(0))
 			require.False(t, chunks.Has(1))
 			require.True(t, chunks.Has(2))
 

--- a/sei-tendermint/internal/statesync/syncer_test.go
+++ b/sei-tendermint/internal/statesync/syncer_test.go
@@ -577,8 +577,7 @@ func TestSyncer_applyChunks_RefetchChunks(t *testing.T) {
 				rts.reactor.syncer.applyChunks(ctx, chunks, fetchStartTime) //nolint:errcheck // purposefully ignore error
 			}()
 
-			time.Sleep(50 * time.Millisecond)
-			require.True(t, chunks.Has(0))
+			waitForChunk(t, chunks, 0, 2*time.Second)
 			require.False(t, chunks.Has(1))
 			require.True(t, chunks.Has(2))
 
@@ -749,4 +748,22 @@ func toABCI(s *snapshot) *abci.Snapshot {
 		Hash:     s.Hash,
 		Metadata: s.Metadata,
 	}
+}
+
+func waitForChunk(
+    t *testing.T,
+    chunks *ChunkStore,
+    index uint32,
+    timeout time.Duration,
+) {
+    t.Helper()
+
+    deadline := time.Now().Add(timeout)
+    for time.Now().Before(deadline) {
+        if chunks.Has(index) {
+            return
+        }
+        time.Sleep(5 * time.Millisecond)
+    }
+    t.Fatalf("chunk %d not received before timeout", index)
 }


### PR DESCRIPTION
Removes fixed time.Sleep usage and introduces a condition-based wait helper to improve test robustness.
Signed off by: Jon S.<totalwine2338@gmail.com>
